### PR TITLE
Mark the serializer as not human readable

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -279,6 +279,11 @@ impl<'a, T: Write> serde::ser::Serializer for &'a mut Encoder<T> {
             ending: false,
         })
     }
+
+    #[inline]
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 macro_rules! end {


### PR DESCRIPTION
The deserializer was already set. The inconsistency between the two
caused uuid::Uuid to perform human readable serialization, which it then
couldn't decode.

Resolves: #3

Signed-off-by: Nathaniel McCallum <npmccallum@redhat.com>
