### PR TITLE
Fix for untyped Enum values bug

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -93,6 +93,9 @@ impl<'a, T: Read> Deserializer<&'a mut Io<T>> {
             }
 
             if title.0 != maj {
+                if title.1 == Minor::Immediate(Immediate(22)) {
+                    continue;
+                }
                 return Err(Error::semantic(offset, msg));
             }
 


### PR DESCRIPTION
Signed-off-by: MikeCamel <mike@p2ptrust.org>

Fixes #5.  May require a broader (read "better, more complete") fix.