### PR TITLE
doc: add links to types referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Ciborium contains CBOR serialization and deserialization implementations for ser
 
 ## Quick Start
 
-You're probably looking for `de::from_reader()` and `ser::into_writer()`, which are
+You're probably looking for [`de::from_reader()`](crate::de::from_reader)
+and [`ser::into_writer()`](crate::ser::into_writer), which are
 the main functions. Note that byte slices are also readers and writers and can be
 passed to these functions just as streams can.
 
-For dynamic CBOR value creation/inspection, see `value::Value`.
+For dynamic CBOR value creation/inspection, see [`value::Value`](crate::value::Value).
 
 ## Design Decisions
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -348,7 +348,7 @@ where
     }
 }
 
-/// Deserializes as CBOR from a type with `impl ciborium::serde::de::Read`
+/// Deserializes as CBOR from a type with [`impl ciborium::serde::de::Read`](crate::serde::de::Read)
 #[inline]
 pub fn from_reader<'de, T: de::Deserialize<'de>, R: Read>(reader: R) -> Result<T, Error<R::Error>>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,12 @@
 //!
 //! # Quick Start
 //!
-//! You're probably looking for `de::from_reader()` and `ser::into_writer()`, which are
+//! You're probably looking for [`de::from_reader()`](crate::de::from_reader)
+//! and [`ser::into_writer()`](crate::ser::into_writer), which are
 //! the main functions. Note that byte slices are also readers and writers and can be
 //! passed to these functions just as streams can.
 //!
-//! For dynamic CBOR value creation/inspection, see `value::Value`.
+//! For dynamic CBOR value creation/inspection, see [`value::Value`](crate::value::Value).
 //!
 //! # Design Decisions
 //!

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -450,7 +450,7 @@ where
     end!();
 }
 
-/// Serializes as CBOR into a type with `impl ciborium::ser::Write`
+/// Serializes as CBOR into a type with [`impl ciborium::ser::Write`](crate::ser::Write)
 #[inline]
 pub fn into_writer<T: ?Sized + ser::Serialize, W: Write>(
     value: &T,


### PR DESCRIPTION
Rust doc in 1.48 added links to types, so to make it easier to get to
the mentioned types, add links in the doc strings.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
