### PR TITLE
`ciborium::value::Value` data extraction utils (inspired by `serde_json`)

### DIFF
--- a/ciborium/src/value/float.rs
+++ b/ciborium/src/value/float.rs
@@ -14,6 +14,22 @@ pub struct TryFromFloatError(());
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Float(f64);
 
+impl Float {
+    /// Gets a reference to the internal value stored in the integer.
+    ///
+    /// ```
+    /// # use ciborium::value::Float;
+    /// #
+    /// let num: Float = 17.0.into();
+    ///
+    /// // We can read the number
+    /// assert_eq!(num.value(), &17.0);
+    /// ```
+    pub fn value(&self) -> &f64 {
+        &self.0
+    }
+}
+
 impl From<f32> for Float {
     #[inline]
     fn from(value: f32) -> Self {

--- a/ciborium/src/value/integer.rs
+++ b/ciborium/src/value/integer.rs
@@ -27,6 +27,22 @@ macro_rules! implfrom {
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Integer(i128);
 
+impl Integer {
+    /// Gets a reference to the intenal value stored in the integer.
+    ///
+    /// ```
+    /// # use ciborium::value::Integer;
+    /// #
+    /// let num: Integer = 17.into();
+    ///
+    /// // We can read the number
+    /// assert_eq!(num.value(), &17_i128);
+    /// ```
+    pub fn value(&self) -> &i128 {
+        &self.0
+    }
+}
+
 implfrom! {
     u8 u16 u32 u64
     i8 i16 i32 i64

--- a/ciborium/src/value/integer.rs
+++ b/ciborium/src/value/integer.rs
@@ -28,7 +28,7 @@ macro_rules! implfrom {
 pub struct Integer(i128);
 
 impl Integer {
-    /// Gets a reference to the intenal value stored in the integer.
+    /// Gets a reference to the internal value stored in the integer.
     ///
     /// ```
     /// # use ciborium::value::Integer;

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -227,6 +227,37 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a `Bool`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Bool(false);
+    ///
+    /// assert!(value.is_bool());
+    /// ```
+    pub fn is_bool(&self) -> bool {
+        self.as_bool().is_some()
+    }
+
+    /// If the `Value` is a `Bool`, returns the associated boolean value. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Bool(false);
+    ///
+    /// // We can read the boolean
+    /// assert_eq!(value.as_bool().unwrap(), false);
+    /// ```
+    pub fn as_bool(&self) -> Option<bool> {
+        match *self {
+            Value::Bool(b) => Some(b),
+            _ => None,
+        }
+    }
+
     /// Returns true if the `Value` is an Array. Returns false otherwise.
     ///
     /// For any Value on which `is_array` returns true, `as_array` and

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -48,6 +48,147 @@ pub enum Value {
     Map(Vec<(Value, Value)>),
 }
 
+impl Value {
+    /// Returns true if the `Value` is a Map. Returns false otherwise.
+    ///
+    /// For any Value on which `is_map` returns true, `as_map` and
+    /// `as_map_mut` are guaranteed to return the map representation of the
+    /// map.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Map(
+    ///     vec![
+    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    ///     ]
+    /// );
+    ///
+    /// assert!(value.is_map());
+    /// ```
+    pub fn is_map(&self) -> bool {
+        self.as_map().is_some()
+    }
+
+    /// If the `Value` is a Map, returns the associated Map data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Map(
+    ///     vec![
+    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    ///     ]
+    /// );
+    ///
+    /// // The length of data is 1 entry (1 key/value pair).
+    /// assert_eq!(value.as_map().unwrap().len(), 1);
+    ///
+    /// // The content of the first element is what we expect
+    /// assert_eq!(
+    ///     value.as_map().unwrap().get(0).unwrap(),
+    ///     &(Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    /// );
+    /// ```
+    pub fn as_map(&self) -> Option<&Vec<(Value, Value)>> {
+        match *self {
+            Value::Map(ref map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a Map, returns the associated mutable Vec.
+    /// Returns None otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let mut value = Value::Map(
+    ///     vec![
+    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    ///     ]
+    /// );
+    ///
+    /// value.as_map_mut().unwrap().clear();
+    /// assert_eq!(value, Value::Map(vec![]));
+    /// ```
+    pub fn as_map_mut(&mut self) -> Option<&mut Vec<(Value, Value)>> {
+        match *self {
+            Value::Map(ref mut map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the `Value` is an Array. Returns false otherwise.
+    ///
+    /// For any Value on which `is_array` returns true, `as_array` and
+    /// `as_array_mut` are guaranteed to return the vector representing the
+    /// array.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Array(
+    ///     vec![
+    ///         Value::Text(String::from("foo")),
+    ///         Value::Text(String::from("bar"))
+    ///     ]
+    /// );
+    ///
+    /// assert!(value.is_array());
+    /// ```
+    pub fn is_array(&self) -> bool {
+        self.as_array().is_some()
+    }
+
+    /// If the `Value` is an Array, returns the associated vector. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Array(
+    ///     vec![
+    ///         Value::Text(String::from("foo")),
+    ///         Value::Text(String::from("bar"))
+    ///     ]
+    /// );
+    ///
+    /// // The length of `value` is 2 elements.
+    /// assert_eq!(value.as_array().unwrap().len(), 2);
+    /// ```
+    pub fn as_array(&self) -> Option<&Vec<Value>> {
+        match *self {
+            Value::Array(ref array) => Some(&*array),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is an Array, returns the associated mutable vector.
+    /// Returns None otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let mut value = Value::Array(
+    ///     vec![
+    ///         Value::Text(String::from("foo")),
+    ///         Value::Text(String::from("bar"))
+    ///     ]
+    /// );
+    ///
+    /// value.as_array_mut().unwrap().clear();
+    /// assert_eq!(value, Value::Array(vec![]));
+    /// ```
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
+        match *self {
+            Value::Array(ref mut list) => Some(list),
+            _ => None,
+        }
+    }
+}
+
 macro_rules! implfrom {
     ($($v:ident($t:ty)),+ $(,)?) => {
         $(

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -128,6 +128,37 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a `Float`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Float(17.0.into());
+    ///
+    /// assert!(value.is_float());
+    /// ```
+    pub fn is_float(&self) -> bool {
+        self.as_float().is_some()
+    }
+
+    /// If the `Value` is a `Float`, returns the associated float data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Float(17.0.into());
+    ///
+    /// // We can read the number
+    /// assert_eq!(value.as_float().unwrap().value(), &17.0_f64);
+    /// ```
+    pub fn as_float(&self) -> Option<&Float> {
+        match *self {
+            Value::Float(ref f) => Some(f),
+            _ => None,
+        }
+    }
+
     /// Returns true if the `Value` is an Array. Returns false otherwise.
     ///
     /// For any Value on which `is_array` returns true, `as_array` and

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -80,73 +80,50 @@ impl Value {
         }
     }
 
-    /// Returns true if the `Value` is a Map. Returns false otherwise.
-    ///
-    /// For any Value on which `is_map` returns true, `as_map` and
-    /// `as_map_mut` are guaranteed to return the map representation of the
-    /// map.
+    /// Returns true if the `Value` is a `Bytes`. Returns false otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
-    /// let value = Value::Map(
-    ///     vec![
-    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
-    ///     ]
-    /// );
+    /// let value = Value::Bytes(vec![104, 101, 108, 108, 111]);
     ///
-    /// assert!(value.is_map());
+    /// assert!(value.is_bytes());
     /// ```
-    pub fn is_map(&self) -> bool {
-        self.as_map().is_some()
+    pub fn is_bytes(&self) -> bool {
+        self.as_bytes().is_some()
     }
 
-    /// If the `Value` is a Map, returns the associated Map data. Returns None
+    /// If the `Value` is a `Bytes`, returns the associated bytes vector. Returns None
     /// otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
-    /// let value = Value::Map(
-    ///     vec![
-    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
-    ///     ]
-    /// );
+    /// let value = Value::Bytes(vec![104, 101, 108, 108, 111]);
     ///
-    /// // The length of data is 1 entry (1 key/value pair).
-    /// assert_eq!(value.as_map().unwrap().len(), 1);
-    ///
-    /// // The content of the first element is what we expect
-    /// assert_eq!(
-    ///     value.as_map().unwrap().get(0).unwrap(),
-    ///     &(Value::Text(String::from("foo")), Value::Text(String::from("bar")))
-    /// );
+    /// assert_eq!(std::str::from_utf8(value.as_bytes().unwrap()).unwrap(), "hello");
     /// ```
-    pub fn as_map(&self) -> Option<&Vec<(Value, Value)>> {
+    pub fn as_bytes(&self) -> Option<&Vec<u8>> {
         match *self {
-            Value::Map(ref map) => Some(map),
+            Value::Bytes(ref bytes) => Some(bytes),
             _ => None,
         }
     }
 
-    /// If the `Value` is a Map, returns the associated mutable Vec.
-    /// Returns None otherwise.
+    /// If the `Value` is a `Bytes`, returns a mutable reference to the associated bytes vector. Returns None
+    /// otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
-    /// let mut value = Value::Map(
-    ///     vec![
-    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
-    ///     ]
-    /// );
+    /// let mut value = Value::Bytes(vec![104, 101, 108, 108, 111]);
+    /// value.as_bytes_mut().unwrap().clear();
     ///
-    /// value.as_map_mut().unwrap().clear();
-    /// assert_eq!(value, Value::Map(vec![]));
+    /// assert_eq!(value, Value::Bytes(vec![]));
     /// ```
-    pub fn as_map_mut(&mut self) -> Option<&mut Vec<(Value, Value)>> {
+    pub fn as_bytes_mut(&mut self) -> Option<&mut Vec<u8>> {
         match *self {
-            Value::Map(ref mut map) => Some(map),
+            Value::Bytes(ref mut bytes) => Some(bytes),
             _ => None,
         }
     }
@@ -215,6 +192,77 @@ impl Value {
     pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
         match *self {
             Value::Array(ref mut list) => Some(list),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the `Value` is a Map. Returns false otherwise.
+    ///
+    /// For any Value on which `is_map` returns true, `as_map` and
+    /// `as_map_mut` are guaranteed to return the map representation of the
+    /// map.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Map(
+    ///     vec![
+    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    ///     ]
+    /// );
+    ///
+    /// assert!(value.is_map());
+    /// ```
+    pub fn is_map(&self) -> bool {
+        self.as_map().is_some()
+    }
+
+    /// If the `Value` is a Map, returns the associated Map data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Map(
+    ///     vec![
+    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    ///     ]
+    /// );
+    ///
+    /// // The length of data is 1 entry (1 key/value pair).
+    /// assert_eq!(value.as_map().unwrap().len(), 1);
+    ///
+    /// // The content of the first element is what we expect
+    /// assert_eq!(
+    ///     value.as_map().unwrap().get(0).unwrap(),
+    ///     &(Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    /// );
+    /// ```
+    pub fn as_map(&self) -> Option<&Vec<(Value, Value)>> {
+        match *self {
+            Value::Map(ref map) => Some(map),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a Map, returns the associated mutable Vec.
+    /// Returns None otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let mut value = Value::Map(
+    ///     vec![
+    ///         (Value::Text(String::from("foo")), Value::Text(String::from("bar")))
+    ///     ]
+    /// );
+    ///
+    /// value.as_map_mut().unwrap().clear();
+    /// assert_eq!(value, Value::Map(vec![]));
+    /// ```
+    pub fn as_map_mut(&mut self) -> Option<&mut Vec<(Value, Value)>> {
+        match *self {
+            Value::Map(ref mut map) => Some(map),
             _ => None,
         }
     }

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -159,6 +159,74 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a `Text`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Text(String::from("hello"));
+    ///
+    /// assert!(value.is_text());
+    /// ```
+    pub fn is_text(&self) -> bool {
+        self.as_text().is_some()
+    }
+
+    /// If the `Value` is a `Text`, returns the associated `String` data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Text(String::from("hello"));
+    ///
+    /// // We can read the number
+    /// assert_eq!(value.as_text().unwrap(), &String::from("hello"));
+    /// ```
+    pub fn as_text(&self) -> Option<&String> {
+        match *self {
+            Value::Text(ref s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a `Text`, returns the associated mutable `String` data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let mut value = Value::Text(String::from("hello"));
+    /// value.as_text_mut().unwrap().clear();
+    ///
+    /// // We can read the number
+    /// assert_eq!(value.as_text().unwrap(), &String::from(""));
+    /// ```
+    pub fn as_text_mut(&mut self) -> Option<&mut String> {
+        match *self {
+            Value::Text(ref mut s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a `Text`, returns the associated `String` as an `&str`. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Text(String::from("hello"));
+    ///
+    /// // We can read the number
+    /// assert_eq!(value.as_str().unwrap(), "hello");
+    /// ```
+    pub fn as_str(&self) -> Option<&str> {
+        match *self {
+            Value::Text(ref s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
     /// Returns true if the `Value` is an Array. Returns false otherwise.
     ///
     /// For any Value on which `is_array` returns true, `as_array` and

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -62,8 +62,8 @@ impl Value {
         self.as_integer().is_some()
     }
 
-    /// If the `Value` is a `Integer`, returns the associated Integer data. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Integer`, returns a reference to the associated `Integer` data.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
@@ -93,8 +93,8 @@ impl Value {
         self.as_bytes().is_some()
     }
 
-    /// If the `Value` is a `Bytes`, returns the associated bytes vector. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Bytes`, returns a reference to the associated bytes vector.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
@@ -110,8 +110,8 @@ impl Value {
         }
     }
 
-    /// If the `Value` is a `Bytes`, returns a mutable reference to the associated bytes vector. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Bytes`, returns a mutable reference to the associated bytes vector.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
@@ -141,15 +141,15 @@ impl Value {
         self.as_float().is_some()
     }
 
-    /// If the `Value` is a `Float`, returns the associated float data. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Float`, returns a reference to the associated float data.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
     /// let value = Value::Float(17.0.into());
     ///
-    /// // We can read the number
+    /// // We can read the float number
     /// assert_eq!(value.as_float().unwrap().value(), &17.0_f64);
     /// ```
     pub fn as_float(&self) -> Option<&Float> {
@@ -172,15 +172,15 @@ impl Value {
         self.as_text().is_some()
     }
 
-    /// If the `Value` is a `Text`, returns the associated `String` data. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Text`, returns a reference to the associated `String` data.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
     /// let value = Value::Text(String::from("hello"));
     ///
-    /// // We can read the number
+    /// // We can read the String
     /// assert_eq!(value.as_text().unwrap(), &String::from("hello"));
     /// ```
     pub fn as_text(&self) -> Option<&String> {
@@ -190,8 +190,8 @@ impl Value {
         }
     }
 
-    /// If the `Value` is a `Text`, returns the associated mutable `String` data. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Text`, returns a mutable reference to the associated `String` data.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
@@ -199,7 +199,6 @@ impl Value {
     /// let mut value = Value::Text(String::from("hello"));
     /// value.as_text_mut().unwrap().clear();
     ///
-    /// // We can read the number
     /// assert_eq!(value.as_text().unwrap(), &String::from(""));
     /// ```
     pub fn as_text_mut(&mut self) -> Option<&mut String> {
@@ -217,7 +216,6 @@ impl Value {
     /// #
     /// let value = Value::Text(String::from("hello"));
     ///
-    /// // We can read the number
     /// assert_eq!(value.as_str().unwrap(), "hello");
     /// ```
     pub fn as_str(&self) -> Option<&str> {
@@ -240,7 +238,7 @@ impl Value {
         self.as_bool().is_some()
     }
 
-    /// If the `Value` is a `Bool`, returns the associated boolean value. Returns None
+    /// If the `Value` is a `Bool`, returns a copy of the associated boolean value. Returns None
     /// otherwise.
     ///
     /// ```
@@ -248,7 +246,6 @@ impl Value {
     /// #
     /// let value = Value::Bool(false);
     ///
-    /// // We can read the boolean
     /// assert_eq!(value.as_bool().unwrap(), false);
     /// ```
     pub fn as_bool(&self) -> Option<bool> {
@@ -284,15 +281,14 @@ impl Value {
         self.as_tag().is_some()
     }
 
-    /// If the `Value` is a `Tag`, returns the associated tag data. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Tag`, returns the associated tag value and a reference to the tag `Value`.
+    /// Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
     /// let value = Value::Tag(61, Box::from(Value::Bytes(vec![104, 101, 108, 108, 111])));
     ///
-    /// // We can read the number
     /// let (tag, data) = value.as_tag().unwrap();
     /// assert_eq!(tag, &61);
     /// assert_eq!(data, &Value::Bytes(vec![104, 101, 108, 108, 111]));
@@ -304,15 +300,14 @@ impl Value {
         }
     }
 
-    /// If the `Value` is a `Tag`, returns the associated tag data. Returns None
-    /// otherwise.
+    /// If the `Value` is a `Tag`, returns the associated tag value and a mutable reference
+    /// to the tag `Value`. Returns None otherwise.
     ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
     /// let mut value = Value::Tag(61, Box::from(Value::Bytes(vec![104, 101, 108, 108, 111])));
     ///
-    /// // We can read the number
     /// let (tag, mut data) = value.as_tag_mut().unwrap();
     /// data.as_bytes_mut().unwrap().clear();
     /// assert_eq!(tag, &61);
@@ -326,10 +321,6 @@ impl Value {
     }
 
     /// Returns true if the `Value` is an Array. Returns false otherwise.
-    ///
-    /// For any Value on which `is_array` returns true, `as_array` and
-    /// `as_array_mut` are guaranteed to return the vector representing the
-    /// array.
     ///
     /// ```
     /// # use ciborium::value::Value;
@@ -347,7 +338,7 @@ impl Value {
         self.as_array().is_some()
     }
 
-    /// If the `Value` is an Array, returns the associated vector. Returns None
+    /// If the `Value` is an Array, returns a reference to the associated vector. Returns None
     /// otherwise.
     ///
     /// ```
@@ -370,7 +361,7 @@ impl Value {
         }
     }
 
-    /// If the `Value` is an Array, returns the associated mutable vector.
+    /// If the `Value` is an Array, returns a mutable reference to the associated vector.
     /// Returns None otherwise.
     ///
     /// ```
@@ -395,10 +386,6 @@ impl Value {
 
     /// Returns true if the `Value` is a Map. Returns false otherwise.
     ///
-    /// For any Value on which `is_map` returns true, `as_map` and
-    /// `as_map_mut` are guaranteed to return the map representation of the
-    /// map.
-    ///
     /// ```
     /// # use ciborium::value::Value;
     /// #
@@ -414,7 +401,7 @@ impl Value {
         self.as_map().is_some()
     }
 
-    /// If the `Value` is a Map, returns the associated Map data. Returns None
+    /// If the `Value` is a Map, returns a reference to the associated Map data. Returns None
     /// otherwise.
     ///
     /// ```
@@ -442,7 +429,7 @@ impl Value {
         }
     }
 
-    /// If the `Value` is a Map, returns the associated mutable Vec.
+    /// If the `Value` is a Map, returns a mutable reference to the associated Map Data.
     /// Returns None otherwise.
     ///
     /// ```
@@ -456,6 +443,7 @@ impl Value {
     ///
     /// value.as_map_mut().unwrap().clear();
     /// assert_eq!(value, Value::Map(vec![]));
+    /// assert_eq!(value.as_map().unwrap().len(), 0);
     /// ```
     pub fn as_map_mut(&mut self) -> Option<&mut Vec<(Value, Value)>> {
         match *self {

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -271,6 +271,60 @@ impl Value {
         matches!(self, Value::Null)
     }
 
+    /// Returns true if the `Value` is a `Tag`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Tag(61, Box::from(Value::Null));
+    ///
+    /// assert!(value.is_tag());
+    /// ```
+    pub fn is_tag(&self) -> bool {
+        self.as_tag().is_some()
+    }
+
+    /// If the `Value` is a `Tag`, returns the associated tag data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Tag(61, Box::from(Value::Bytes(vec![104, 101, 108, 108, 111])));
+    ///
+    /// // We can read the number
+    /// let (tag, data) = value.as_tag().unwrap();
+    /// assert_eq!(tag, &61);
+    /// assert_eq!(data, &Value::Bytes(vec![104, 101, 108, 108, 111]));
+    /// ```
+    pub fn as_tag(&self) -> Option<(&u64, &Value)> {
+        match &*self {
+            Value::Tag(ref tag, data) => Some((tag, data)),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a `Tag`, returns the associated tag data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let mut value = Value::Tag(61, Box::from(Value::Bytes(vec![104, 101, 108, 108, 111])));
+    ///
+    /// // We can read the number
+    /// let (tag, mut data) = value.as_tag_mut().unwrap();
+    /// data.as_bytes_mut().unwrap().clear();
+    /// assert_eq!(tag, &61);
+    /// assert_eq!(data, &Value::Bytes(vec![]));
+    /// ```
+    pub fn as_tag_mut(&mut self) -> Option<(&u64, &mut Value)> {
+        match *self {
+            Value::Tag(ref tag, ref mut data) => Some((tag, data.as_mut())),
+            _ => None,
+        }
+    }
+
     /// Returns true if the `Value` is an Array. Returns false otherwise.
     ///
     /// For any Value on which `is_array` returns true, `as_array` and

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -258,6 +258,19 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a `Null`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Null;
+    ///
+    /// assert!(value.is_null());
+    /// ```
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
     /// Returns true if the `Value` is an Array. Returns false otherwise.
     ///
     /// For any Value on which `is_array` returns true, `as_array` and

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -49,6 +49,37 @@ pub enum Value {
 }
 
 impl Value {
+    /// Returns true if the `Value` is an `Integer`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Integer(17.into());
+    ///
+    /// assert!(value.is_integer());
+    /// ```
+    pub fn is_integer(&self) -> bool {
+        self.as_integer().is_some()
+    }
+
+    /// If the `Value` is a `Integer`, returns the associated Integer data. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use ciborium::value::Value;
+    /// #
+    /// let value = Value::Integer(17.into());
+    ///
+    /// // We can read the number
+    /// assert_eq!(value.as_integer().unwrap().value(), &17_i128);
+    /// ```
+    pub fn as_integer(&self) -> Option<&Integer> {
+        match *self {
+            Value::Integer(ref int) => Some(int),
+            _ => None,
+        }
+    }
+
     /// Returns true if the `Value` is a Map. Returns false otherwise.
     ///
     /// For any Value on which `is_map` returns true, `as_map` and


### PR DESCRIPTION
Hello,
this PR introduces some utility functions to easily extract data out of generic `Value` objects. This is inspired by the utilities you get with `serde_json` for their respective `Value` type (see https://github.com/serde-rs/json/blob/master/src/value/mod.rs#L345).

Here's an example of how this might work:

```rust
use ciborium::value::Value;

let mut value = Value::Array(
    vec![
        Value::Text(String::from("foo")),
        Value::Text(String::from("bar"))
    ]
);

value.as_array_mut().unwrap().clear();
assert_eq!(value, Value::Array(vec![]));
```

## TODO

- [x] impl `is_map`
- [x] impl `as_map`
- [x] impl `as_map_mut`
- [x] impl `is_array`
- [x] impl `as_array`
- [x] impl `as_array_mut`
- [x] impl `is_integer`
- [x] impl `as_integer`
- [x] impl `is_bytes`
- [x] impl `as_bytes`
- [x] impl `as_bytes_mut`
- [x] impl `is_float`
- [x] impl `as_float`
- [x] impl `is_text`
- [x] impl `as_text`
- [x] impl `as_text_mut`
- [x] impl `as_str`
- [x] impl `is_bool`
- [x] impl `as_bool`
- [x] impl `is_null`
- [x] impl `is_tag`
- [x] impl `as_tag`
- [x] impl `as_tag_mut`