### PR TITLE
Add a new CanonicalValue type

### DIFF
--- a/ciborium/src/value/canonical.rs
+++ b/ciborium/src/value/canonical.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::value::Value;
+use serde::{de, ser};
+use std::cmp::Ordering;
+
+/// Manually serialize values to compare them.
+fn serialized_canonical_cmp(v1: &Value, v2: &Value) -> Ordering {
+    // There is an optimization to be done here, but it would take a lot more code
+    // and using mixing keys, Arrays or Maps as CanonicalValue is probably not the
+    // best use of this type as it is meant mainly to be used as keys.
+
+    let mut bytes1 = Vec::new();
+    let _ = crate::ser::into_writer(v1, &mut bytes1);
+    let mut bytes2 = Vec::new();
+    let _ = crate::ser::into_writer(v2, &mut bytes2);
+
+    match bytes1.len().cmp(&bytes2.len()) {
+        Ordering::Equal => bytes1.cmp(&bytes2),
+        x => x,
+    }
+}
+
+/// Compares two values uses canonical comparison, as defined in both
+/// RFC 7049 Section 3.9 (regarding key sorting) and RFC 8949 4.2.3 (as errata).
+///
+/// In short, the comparison follow the following rules:
+///   - If two keys have different lengths, the shorter one sorts earlier;
+///   - If two keys have the same length, the one with the lower value in
+///     (byte-wise) lexical order sorts earlier.
+///
+/// This specific comparison allows Maps and sorting that respect these two rules.
+pub fn cmp_value(v1: &Value, v2: &Value) -> Ordering {
+    use Value::*;
+
+    match (v1, v2) {
+        (Integer(i), Integer(o)) => {
+            // Because of the first rule above, two numbers might be in a different
+            // order than regular i128 comparison. For example, 10 < -1 in
+            // canonical ordering, since 10 serializes to `0x0a` and -1 to `0x20`,
+            // and -1 < -1000 because of their lengths.
+            i.canonical_cmp(o)
+        }
+        (Text(s), Text(o)) => match s.len().cmp(&o.len()) {
+            Ordering::Equal => s.cmp(o),
+            x => x,
+        },
+        (Bool(s), Bool(o)) => s.cmp(o),
+        (Null, Null) => Ordering::Equal,
+        (Tag(t, v), Tag(ot, ov)) => match Value::from(*t).partial_cmp(&Value::from(*ot)) {
+            Some(Ordering::Equal) | None => match v.partial_cmp(&ov) {
+                Some(x) => x,
+                None => serialized_canonical_cmp(v1, v2),
+            },
+            Some(x) => x,
+        },
+        (_, _) => serialized_canonical_cmp(v1, v2),
+    }
+}
+
+/// A CBOR Value that impl Ord and Eq to allow sorting of values as defined in both
+/// RFC 7049 Section 3.9 (regarding key sorting) and RFC 8949 4.2.3 (as errata).
+///
+/// Since a regular [Value] can be
+#[derive(Clone, Debug)]
+pub struct CanonicalValue(Value);
+
+impl PartialEq for CanonicalValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for CanonicalValue {}
+
+impl From<Value> for CanonicalValue {
+    fn from(v: Value) -> Self {
+        Self(v)
+    }
+}
+
+impl Into<Value> for CanonicalValue {
+    fn into(self) -> Value {
+        self.0
+    }
+}
+
+impl ser::Serialize for CanonicalValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> de::Deserialize<'de> for CanonicalValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Value::deserialize(deserializer).map(Into::into)
+    }
+
+    fn deserialize_in_place<D>(deserializer: D, place: &mut Self) -> Result<(), D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Value::deserialize_in_place(deserializer, &mut place.0)
+    }
+}
+
+impl Ord for CanonicalValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        cmp_value(&self.0, &other.0)
+    }
+}
+
+impl PartialOrd for CanonicalValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(cmp_value(&self.0, &other.0))
+    }
+}

--- a/ciborium/src/value/integer.rs
+++ b/ciborium/src/value/integer.rs
@@ -85,6 +85,15 @@ impl Integer {
                     (true, false) => {
                         Ordering::Greater
                     }
+                    (true, true) => {
+                        // For negative numbers the byte order puts numbers closer to 0 which
+                        // are lexically higher, lower. So -1 < -2 when sorting by be_bytes().
+                        match self.0.cmp(&other.0) {
+                            Ordering::Less => Ordering::Greater,
+                            Ordering::Equal => Ordering::Equal,
+                            Ordering::Greater => Ordering::Less,
+                        }
+                    }
                     (_, _) => {
                         self.0.cmp(&other.0)
                     }

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -3,6 +3,7 @@
 //! A dynamic CBOR value
 
 mod integer;
+mod canonical;
 
 mod de;
 mod error;
@@ -10,6 +11,7 @@ mod ser;
 
 pub use error::Error;
 pub use integer::Integer;
+pub use canonical::CanonicalValue;
 
 use alloc::{boxed::Box, string::String, vec::Vec};
 

--- a/ciborium/tests/canonical.rs
+++ b/ciborium/tests/canonical.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate std;
+
+use std::collections::BTreeMap;
+use ciborium::cbor;
+use ciborium::value::{ CanonicalValue, };
+use rand::prelude::*;
+
+macro_rules! cval {
+    ($x:expr) => {
+        CanonicalValue::from(val!($x))
+    };
+}
+
+macro_rules! val {
+    ($x:expr) => {
+        cbor!($x).unwrap()
+    };
+}
+
+#[test]
+fn rfc8949_example() {
+    let mut array: Vec<CanonicalValue> = vec![
+        cval!(10),
+        cval!(-1),
+        cval!(false),
+        cval!(100),
+        cval!("z"),
+        cval!([-1]),
+        cval!("aa"),
+        cval!([100]),
+    ];
+    let golden = array.clone();
+
+    // Shuffle the array.
+    array.shuffle(&mut rand::thread_rng());
+
+    array.sort();
+
+    assert_eq!(array, golden);
+}
+
+#[test]
+fn map() {
+    let mut map = BTreeMap::new();
+    map.insert(cval!(false), val!(2));
+    map.insert(cval!([-1]), val!(5));
+    map.insert(cval!(-1), val!(1));
+    map.insert(cval!(10), val!(0));
+    map.insert(cval!(100), val!(3));
+    map.insert(cval!([100]), val!(7));
+    map.insert(cval!("z"), val!(4));
+    map.insert(cval!("aa"), val!(6));
+
+    let mut bytes1 = Vec::new();
+    ciborium::ser::into_writer(&map, &mut bytes1).unwrap();
+
+    assert_eq!(hex::encode(&bytes1), "a80a002001f402186403617a048120056261610681186407");
+}

--- a/ciborium/tests/canonical.rs
+++ b/ciborium/tests/canonical.rs
@@ -58,3 +58,31 @@ fn map() {
 
     assert_eq!(hex::encode(&bytes1), "a80a002001f402186403617a048120056261610681186407");
 }
+
+#[test]
+fn negative_numbers() {
+    let mut array: Vec<CanonicalValue> = vec![
+        cval!(10),
+        cval!(-1),
+        cval!(-2),
+        cval!(-3),
+        cval!(-4),
+        cval!(false),
+        cval!(100),
+        cval!(-100),
+        cval!(-200),
+        cval!("z"),
+        cval!([-1]),
+        cval!(-300),
+        cval!("aa"),
+        cval!([100]),
+    ];
+    let golden = array.clone();
+
+    // Shuffle the array.
+    array.shuffle(&mut rand::thread_rng());
+
+    array.sort();
+
+    assert_eq!(array, golden);
+}


### PR DESCRIPTION
This allows programs to sort maps according to the canonical sorting rules.
The Value itself is good with the other canonical rules.

Fixes #28

