### PR TITLE
feat: transparent conversion between ByteBuf and Vec<u8>

### DIFF
--- a/ciborium/tests/codec.rs
+++ b/ciborium/tests/codec.rs
@@ -397,3 +397,22 @@ enum Enum {
     Tuple(u8, u16),
     Struct { first: u8, second: u16 },
 }
+
+#[rstest(
+    input,
+    case(vec![]),
+    case(vec![0u8, 1, 2, 3]),
+)]
+fn byte_vec_serde_bytes_compatibility(input: Vec<u8>) {
+    use serde_bytes::ByteBuf;
+
+    let mut buf = Vec::new();
+    into_writer(&input, &mut buf).unwrap();
+    let bytes: ByteBuf = from_reader(&buf[..]).unwrap();
+    assert_eq!(input, bytes.to_vec());
+
+    let mut buf = Vec::new();
+    into_writer(&ByteBuf::from(input.clone()), &mut buf).unwrap();
+    let bytes: Vec<u8> = from_reader(&buf[..]).unwrap();
+    assert_eq!(input, bytes);
+}


### PR DESCRIPTION
This change makes it possible to decode a `serde_bytes::ByteBuf` from
CBOR data encoded as a `Vec<u8>` (and in the other direction, too).

The `ByteBuf` -> `Vec<u8>` direction is not optimal because it allocates
an additional buffer, but this should not be a problem because decoding
one byte at a time ruins performance anyway.

Context: our project migrates from serde_cbor to ciborium.
ciborium is faster and generates compact code, but we have old data sets
generated using inefficient `Vec<u8>` encoding. We want to be able to
decode them with ciborium, which currently does not provide
compatibility between `Vec<u8>` and `ByteBuf` as serde_cbor did.

Signed-off-by: Roman Kashitsyn <roman@dfinity.org>