### PR TITLE
Build with `std` on docs.rs

### DIFF
--- a/ciborium-io/Cargo.toml
+++ b/ciborium-io/Cargo.toml
@@ -22,3 +22,6 @@ is-it-maintained-open-issues = { repository = "enarx/ciborium" }
 [features]
 alloc = []
 std = ["alloc"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/ciborium-ll/Cargo.toml
+++ b/ciborium-ll/Cargo.toml
@@ -29,3 +29,6 @@ hex = "0.4"
 [features]
 alloc = []
 std = ["alloc"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/ciborium/Cargo.toml
+++ b/ciborium/Cargo.toml
@@ -33,3 +33,6 @@ hex = "0.4"
 [features]
 default = ["std"]
 std = ["ciborium-io/std", "serde/std"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
I spent a little while chasing my tail trying to figure out how best to use `ciborium-io` with a `std::io::Write` value, when the impl was there all along 🤦🏻‍♂️

This bit of package metadata should make `docs.rs` build with the `"std"` feature enabled, so the impl will show up in the generated documentation.
