### PR TITLE
Use `DeserializeOwned` for `from_reader`

### DIFF
--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -799,7 +799,7 @@ where
 
 /// Deserializes as CBOR from a type with [`impl ciborium_io::Read`](ciborium_io::Read)
 #[inline]
-pub fn from_reader<'de, T: de::Deserialize<'de>, R: Read>(reader: R) -> Result<T, Error<R::Error>>
+pub fn from_reader<T: de::DeserializeOwned, R: Read>(reader: R) -> Result<T, Error<R::Error>>
 where
     R::Error: core::fmt::Debug,
 {

--- a/ciborium/tests/codec.rs
+++ b/ciborium/tests/codec.rs
@@ -10,7 +10,7 @@ use ciborium::value::Value;
 use ciborium::{cbor, de::from_reader, ser::into_writer};
 
 use rstest::rstest;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 macro_rules! val {
     ($x:expr) => {
@@ -275,7 +275,7 @@ macro_rules! map {
     case(Enum::Tuple(56, 67), cbor!({"Tuple" => [56, 67]}).unwrap(), "a1655475706c658218381843", false, same), // Not In RFC
     case(Enum::Struct { first: 78, second: 89 }, cbor!({ "Struct" => { "first" => 78, "second" => 89 }}).unwrap(), "a166537472756374a2656669727374184e667365636f6e641859", false, same), // Not In RFC
 )]
-fn codec<'de, T: Serialize + Clone, V: Debug + PartialEq + Deserialize<'de>, F: Fn(T) -> V>(
+fn codec<'de, T: Serialize + Clone, V: Debug + PartialEq + DeserializeOwned, F: Fn(T) -> V>(
     input: T,
     value: Value,
     bytes: &str,

--- a/ciborium/tests/tag.rs
+++ b/ciborium/tests/tag.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 use ciborium::{de::from_reader, ser::into_writer, tag::*, value::Value};
 use rstest::rstest;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 
 use core::fmt::Debug;
 
@@ -20,7 +20,7 @@ use core::fmt::Debug;
     case(Accepted::<_, 6>(true), "c7f5", Value::Tag(7, Value::Bool(true).into()), false, false),
     case(Accepted::<_, 6>(true), "f5", Value::Bool(true), false, true),
 )]
-fn test<'de, T: Serialize + Deserialize<'de> + Debug + Eq>(
+fn test<T: Serialize + DeserializeOwned + Debug + Eq>(
     item: T,
     bytes: &str,
     value: Value,


### PR DESCRIPTION
Based on #45 I saw that `from_reader` uses the wrong trait bounds for `T`. It does not support arbitrary types, but only those, which do not borrow from the input value. This can be expressed with `DeserializeOwned`.

The `Read` trait always returns owned data and has no concept of borrowing from the input. Therefore, any type deserialize with the function also cannot borrow from the input.

You see the same trait bound on `serde_json::from_reader`.

The changes in `tests/` are simply to get the tests compiling afterwards.