### PR TITLE
Support decoding enums encoded with an indefinite length map

### DIFF
--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -566,6 +566,7 @@ where
             match self.decoder.pull()? {
                 Header::Tag(..) => continue,
                 Header::Map(Some(1)) => (),
+                Header::Map(None) => (),
                 header @ Header::Text(..) => self.decoder.push(header),
                 header => return Err(header.expected("enum")),
             }


### PR DESCRIPTION
Enums encoded using maps of indefinite length cannot be decoded.

This document, which uses maps of a definite length,

```
# {"User":{"name":"John Doe"}}
a1                        # map(1)
   64                     #   text(4)
      55736572            #     "User"
   a1                     #   map(1)
      64                  #     text(4)
         6e616d65         #       "name"
      68                  #     text(8)
         4a6f686e20446f65 #       "John Doe"
```

encodes the exact same data as this document, which uses maps of an indefinite length

```
# {_ "User":{_ "name":"John Doe"}}
bf                        # map(*)
   64                     #   text(4)
      55736572            #     "User"
   bf                     #   map(*)
      64                  #     text(4)
         6e616d65         #       "name"
      68                  #     text(8)
         4a6f686e20446f65 #       "John Doe"
      ff                  #     break
   ff                     #   break
```

However, because the [implementation for `deserialize_enum`](https://github.com/enarx/ciborium/blob/2ca375e6b33d1ade5a5798792278b35a807b748e/ciborium/src/de/mod.rs#L568) requires the map length to be exactly 1, only the first document can be decoded into an enum that looks like this:

```rust
enum Something {
    User { name: String }
}
```

