### PR TITLE
Update no-std write_all implementation to use mem::take

### DIFF
--- a/ciborium-io/src/lib.rs
+++ b/ciborium-io/src/lib.rs
@@ -136,7 +136,7 @@ impl Write for &mut [u8] {
             return Err(OutOfSpace(()));
         }
 
-        let (prefix, suffix) = core::mem::replace(self, &mut []).split_at_mut(data.len());
+        let (prefix, suffix) = core::mem::take(self).split_at_mut(data.len());
         prefix.copy_from_slice(data);
         *self = suffix;
         Ok(())


### PR DESCRIPTION
Checking the project with the latest `clippy` tool raises the following error in the `ciborium-ll` crate:

```rust
$ cargo +stable clippy -- -V
clippy 0.1.66 (69f9c33 2022-12-12)
$ cargo +stable clippy --no-default-features
    Checking ciborium-io v0.2.0 (/home/vpetrigo/projects/rust/ciborium/ciborium-io)
error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> ciborium-io/src/lib.rs:139:32
    |
139 |         let (prefix, suffix) = core::mem::replace(self, &mut []).split_at_mut(data.len());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(self)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default
note: the lint level is defined here
   --> ciborium-io/src/lib.rs:19:9
    |
19  | #![deny(clippy::all)]
    |         ^^^^^^^^^^^
    = note: `#[deny(clippy::mem_replace_with_default)]` implied by `#[deny(clippy::all)]`

error: could not compile `ciborium-io` due to previous error
```

So, these changes address that warnings and switch the implementation to use `mem::take` instead of `mem::replace`.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
