### PR TITLE
fix: Handle byte strings for field names

### DIFF
--- a/ciborium-ll/src/seg.rs
+++ b/ciborium-ll/src/seg.rs
@@ -81,7 +81,7 @@ impl Parser for Text {
             Ok(s) => {
                 self.stored = 0;
                 s
-            },
+            }
             Err(e) => {
                 let valid_len = e.valid_up_to();
                 let invalid_len = bytes.len() - valid_len;

--- a/ciborium/tests/codec.rs
+++ b/ciborium/tests/codec.rs
@@ -416,3 +416,18 @@ fn byte_vec_serde_bytes_compatibility(input: Vec<u8>) {
     let bytes: Vec<u8> = from_reader(&buf[..]).unwrap();
     assert_eq!(input, bytes);
 }
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+struct Foo {
+    bar: u8,
+}
+
+#[rstest(input, expected,
+    case("a163626172182a", Foo { bar: 42 }),
+    case("a143626172182a", Foo { bar: 42 }),
+)]
+fn handle_struct_field_names(input: &str, expected: Foo) {
+    let buf = hex::decode(input).unwrap();
+    let read = from_reader(&buf[..]).unwrap();
+    assert_eq!(expected, read);
+}


### PR DESCRIPTION
I'm not able to deserialize CBOR maps where keys has been encoded as byte strings (type 2). This change handles both types of strings from CBOR as field names in structures