### PR TITLE
chore: release 0.2.1

### DIFF
--- a/ciborium-io/Cargo.toml
+++ b/ciborium-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nathaniel McCallum <npmccallum@profian.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/ciborium-ll/Cargo.toml
+++ b/ciborium-ll/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nathaniel McCallum <npmccallum@profian.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -21,7 +21,7 @@ is-it-maintained-issue-resolution = { repository = "enarx/ciborium" }
 is-it-maintained-open-issues = { repository = "enarx/ciborium" }
 
 [dependencies]
-ciborium-io = { path = "../ciborium-io", version = "0.2.0" }
+ciborium-io = { path = "../ciborium-io", version = "0.2.1" }
 half = "1.6"
 
 [dev-dependencies]

--- a/ciborium/Cargo.toml
+++ b/ciborium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nathaniel McCallum <npmccallum@profian.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -21,8 +21,8 @@ is-it-maintained-issue-resolution = { repository = "enarx/ciborium" }
 is-it-maintained-open-issues = { repository = "enarx/ciborium" }
 
 [dependencies]
-ciborium-ll = { path = "../ciborium-ll", version = "0.2.0" }
-ciborium-io = { path = "../ciborium-io", version = "0.2.0", features = ["alloc"] }
+ciborium-ll = { path = "../ciborium-ll", version = "0.2.1" }
+ciborium-io = { path = "../ciborium-io", version = "0.2.1", features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Prep for a v0.2.1 release.
Ref https://github.com/enarx/ciborium/pull/77
