### PR TITLE
feat: add from_reader_with_recursion_limit

### DIFF
--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -831,3 +831,27 @@ where
 
     T::deserialize(&mut reader)
 }
+
+/// Deserializes as CBOR from a type with [`impl ciborium_io::Read`](ciborium_io::Read), with
+/// a specified maximum recursion limit.  Inputs that are nested beyond the specified limit
+/// will result in [`Error::RecursionLimitExceeded`] .
+///
+/// Set a high recursion limit at your own risk (of stack exhaustion)!
+#[inline]
+pub fn from_reader_with_recursion_limit<T: de::DeserializeOwned, R: Read>(
+    reader: R,
+    recurse_limit: usize,
+) -> Result<T, Error<R::Error>>
+where
+    R::Error: core::fmt::Debug,
+{
+    let mut scratch = [0; 4096];
+
+    let mut reader = Deserializer {
+        decoder: reader.into(),
+        scratch: &mut scratch,
+        recurse: recurse_limit,
+    };
+
+    T::deserialize(&mut reader)
+}

--- a/ciborium/tests/recursion.rs
+++ b/ciborium/tests/recursion.rs
@@ -7,7 +7,7 @@
 //! test each of these types here to ensure there is no stack overflow.
 
 use ciborium::{
-    de::{from_reader, Error},
+    de::{from_reader, from_reader_with_recursion_limit, Error},
     value::Value,
 };
 
@@ -44,5 +44,49 @@ fn text() {
     match from_reader::<Value, _>(&bytes[..]).unwrap_err() {
         Error::Io(..) => (),
         e => panic!("incorrect error: {:?}", e),
+    }
+}
+
+#[test]
+fn array_limit() {
+    let bytes = [0x9f; 128 * 1024];
+    for limit in 16..256 {
+        match from_reader_with_recursion_limit::<Value, _>(&bytes[..], limit).unwrap_err() {
+            Error::RecursionLimitExceeded => (),
+            e => panic!("incorrect error with limit {}: {:?}", limit, e),
+        }
+        // Data that is nested beyond the limit should fail with `RecursionLimitExceeded`
+        match from_reader_with_recursion_limit::<Value, _>(&bytes[..limit + 1], limit).unwrap_err()
+        {
+            Error::RecursionLimitExceeded => (),
+            e => panic!("incorrect error with limit {}: {:?}", limit, e),
+        }
+        // Data that is nested within the limit fails with a different error.
+        match from_reader_with_recursion_limit::<Value, _>(&bytes[..limit], limit).unwrap_err() {
+            Error::Io(..) => (),
+            e => panic!("incorrect error with limit {}: {:?}", limit, e),
+        }
+    }
+}
+
+#[test]
+fn map_limit() {
+    let bytes = [0xbf; 128 * 1024];
+    for limit in 16..256 {
+        match from_reader_with_recursion_limit::<Value, _>(&bytes[..], limit).unwrap_err() {
+            Error::RecursionLimitExceeded => (),
+            e => panic!("incorrect error with limit {}: {:?}", limit, e),
+        }
+        // Data that is nested beyond the limit should fail with `RecursionLimitExceeded`
+        match from_reader_with_recursion_limit::<Value, _>(&bytes[..limit + 1], limit).unwrap_err()
+        {
+            Error::RecursionLimitExceeded => (),
+            e => panic!("incorrect error with limit {}: {:?}", limit, e),
+        }
+        // Data that is nested within the limit fails with a different error.
+        match from_reader_with_recursion_limit::<Value, _>(&bytes[..limit], limit).unwrap_err() {
+            Error::Io(..) => (),
+            e => panic!("incorrect error with limit {}: {:?}", limit, e),
+        }
     }
 }


### PR DESCRIPTION
This change adds a from_reader_with_recursion_limit() variant of from_reader(), allowing the maximum recursion limit to be set explicitly.

Fixes #58 which asks for the ability to set a higher recursion limit, but this is mainly intended for environments where the default limit of 256 is too large (i.e. the stack gets exhausted before the limit is hit).

