### PR TITLE
Make ciborium-ll usable standalone for std builds

### DIFF
--- a/ciborium-ll/Cargo.toml
+++ b/ciborium-ll/Cargo.toml
@@ -29,7 +29,7 @@ hex = "0.4"
 
 [features]
 alloc = []
-std = ["alloc"]
+std = ["alloc", "ciborium-io/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Without this change, attempts to use anything in `ciborium-ll` that refers to `ciborium_io::Write` is basically unusable, because `ciborium-io`'s `std` feature is never enabled, meaning that the types that implement `io::std::Write` aren't available for use, which leaves things in a rather tricky state.

Signed-off-by: Matt Palmer <matt@hezmatt.org>