### PR TITLE
Update spelling for error type in ciborium docs

### DIFF
--- a/ciborium-ll/src/dec.rs
+++ b/ciborium-ll/src/dec.rs
@@ -7,7 +7,7 @@ use ciborium_io::Read;
 pub enum Error<T> {
     /// An error occurred while reading bytes
     ///
-    /// Contains the underlying error reaturned while reading.
+    /// Contains the underlying error returned while reading.
     Io(T),
 
     /// An error occurred while parsing bytes

--- a/ciborium/src/de/error.rs
+++ b/ciborium/src/de/error.rs
@@ -10,7 +10,7 @@ use serde::de::{Error as DeError, StdError};
 pub enum Error<T> {
     /// An error occurred while reading bytes
     ///
-    /// Contains the underlying error reaturned while reading.
+    /// Contains the underlying error returned while reading.
     Io(T),
 
     /// An error occurred while parsing bytes


### PR DESCRIPTION
Spellcheck in error type in ciborium docs.

Link: https://docs.rs/ciborium/latest/ciborium/de/enum.Error.html#variant.Io

>Contains the underlying error "reaturned" while reading.
