### PR TITLE
Correctly set minimum serde version to v1.0.100

### DIFF
--- a/ciborium/Cargo.toml
+++ b/ciborium/Cargo.toml
@@ -23,7 +23,7 @@ is-it-maintained-open-issues = { repository = "enarx/ciborium" }
 [dependencies]
 ciborium-ll = { path = "../ciborium-ll", version = "0.2.1" }
 ciborium-io = { path = "../ciborium-io", version = "0.2.1", features = ["alloc"] }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.100", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 serde_bytes = "0.11"


### PR DESCRIPTION
This allows ciborium to build with the `-Z minimal-versions` cargo flag.

---

Currently, ciborium specifies serde v1.0 as its dependency. This may be problematic since version v1.0.0 of serde doesn't allow ciborium to build, so if a project was using version an early version of serde and pulled in ciborium, their project would fail to build until they update serde to a later version. Additionally, any project that pulls in ciborium would fail to build using the `-Z minimal-versions flag`. Since ciborium is used by popular crates such as criterion, this affects a large part of the ecosystem.

Testing was done using `cargo +nightly -Z minimal-versions update && cargo test --all-features`, and through manual bisecting I found v1.0.100 to be the earliest version of serde that works and passes the test suite.

For more information, see [PSA: Please specify precise dependency versions in Cargo.toml](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277).