### PR TITLE
Update `half` library

### DIFF
--- a/ciborium-ll/Cargo.toml
+++ b/ciborium-ll/Cargo.toml
@@ -22,14 +22,14 @@ is-it-maintained-open-issues = { repository = "enarx/ciborium" }
 
 [dependencies]
 ciborium-io = { path = "../ciborium-io", version = "0.2.1" }
-half = "1.6"
+half = { version = "2.2", default-features = false}
 
 [dev-dependencies]
 hex = "0.4"
 
 [features]
 alloc = []
-std = ["alloc"]
+std = ["alloc", "half/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The reason for the update of the `half` library is the `no_std` support.
The old version did not have `std` feature and was trying to use `fmodf` function from the standard math library, which is not available on `no_std` environment (at least on windows).