### PR TITLE
deserialize_bytes with data bigger than 4k

### DIFF
--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -366,9 +366,13 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Bytes(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-                    visitor.visit_bytes(&self.scratch[..len])
+                Header::Bytes(Some(len)) => {
+                    if len <= self.scratch.len() {
+                        self.decoder.read_exact(&mut self.scratch[..len])?;
+                        visitor.visit_bytes(&self.scratch[..len])
+                    } else {
+                        visitor.visit_byte_buf(vec![0u8; len])
+                    }
                 }
 
                 Header::Array(len) => self.recurse(|me| {


### PR DESCRIPTION
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

close https://github.com/enarx/ciborium/issues/96

The test format is not like the others but I didn't find a way to leverage the existing test suite to expose the error.
