### PR TITLE
fix: satisfy clippy

### DIFF
--- a/ciborium/src/value/de.rs
+++ b/ciborium/src/value/de.rs
@@ -243,10 +243,8 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
                     visitor.visit_u64(x)
                 } else if let Ok(x) = i64::try_from(*x) {
                     visitor.visit_i64(x)
-                } else if let Ok(x) = i128::try_from(*x) {
-                    visitor.visit_i128(x)
                 } else {
-                    unreachable!()
+                    visitor.visit_i128(i128::from(*x))
                 }
             }
 

--- a/ciborium/src/value/ser.rs
+++ b/ciborium/src/value/ser.rs
@@ -50,10 +50,8 @@ impl ser::Serialize for Value {
                     serializer.serialize_i64(x)
                 } else if let Ok(x) = u128::try_from(*x) {
                     serializer.serialize_u128(x)
-                } else if let Ok(x) = i128::try_from(*x) {
-                    serializer.serialize_i128(x)
                 } else {
-                    unreachable!()
+                    serializer.serialize_i128(i128::from(*x))
                 }
             }
 


### PR DESCRIPTION
Clippy from Rust 1.75 onward has a check for use of fallible conversion when an infallible conversion would have done the trick.
