### PR TITLE
fix: indefinite strings can't contain indefinite strings

### DIFF
--- a/ciborium/tests/error.rs
+++ b/ciborium/tests/error.rs
@@ -131,8 +131,8 @@ fn eof() -> Error<std::io::Error> {
     case("7f4100ff", Error::Syntax(1)),
 
     // Indefinite-length string chunks not definite length:
-    //case("5f5f4100ffff", Error::Syntax(0)), These should fail, but do not currently.
-    //case("7f7f6100ffff", Error::Syntax(0)),
+    case("5f5f4100ffff", Error::Syntax(1)),
+    case("7f7f6100ffff", Error::Syntax(1)),
 
     // Break occurring on its own outside of an indefinite-length item:
     case("ff", Error::Semantic(None, "invalid type: break, expected non-break".into())),

--- a/ciborium/tests/recursion.rs
+++ b/ciborium/tests/recursion.rs
@@ -33,7 +33,7 @@ fn map() {
 fn bytes() {
     let bytes = [0x5f; 128 * 1024];
     match from_reader::<Value, _>(&bytes[..]).unwrap_err() {
-        Error::Io(..) => (),
+        Error::Syntax(..) => (),
         e => panic!("incorrect error: {:?}", e),
     }
 }
@@ -42,7 +42,7 @@ fn bytes() {
 fn text() {
     let bytes = [0x7f; 128 * 1024];
     match from_reader::<Value, _>(&bytes[..]).unwrap_err() {
-        Error::Io(..) => (),
+        Error::Syntax(..) => (),
         e => panic!("incorrect error: {:?}", e),
     }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
