### PR TITLE
refactor: remove unnecessary bounds from types

### DIFF
--- a/ciborium-ll/src/dec.rs
+++ b/ciborium-ll/src/dec.rs
@@ -28,7 +28,7 @@ impl<T> From<T> for Error<T> {
 /// This decoder manages the low-level decoding of CBOR items into `Header`
 /// objects. It also contains utility functions for parsing segmented bytes
 /// and text inputs.
-pub struct Decoder<R: Read> {
+pub struct Decoder<R> {
     reader: R,
     offset: usize,
     buffer: Option<Title>,

--- a/ciborium-ll/src/enc.rs
+++ b/ciborium-ll/src/enc.rs
@@ -6,7 +6,7 @@ use ciborium_io::Write;
 ///
 /// This structure wraps a writer and provides convenience functions for
 /// writing `Header` objects to the wire.
-pub struct Encoder<W: Write>(W);
+pub struct Encoder<W>(W);
 
 impl<W: Write> From<W> for Encoder<W> {
     #[inline]

--- a/ciborium-ll/src/seg.rs
+++ b/ciborium-ll/src/seg.rs
@@ -111,7 +111,7 @@ impl Parser for Text {
 ///
 /// This type represents a single bytes or text segment on the wire. It can be
 /// read out in parsed chunks based on the size of the input scratch buffer.
-pub struct Segment<'r, R: Read, P: Parser> {
+pub struct Segment<'r, R, P> {
     reader: &'r mut Decoder<R>,
     unread: usize,
     offset: usize,
@@ -169,14 +169,14 @@ enum State {
 ///
 /// CBOR allows for bytes or text items to be segmented. This type represents
 /// the state of that segmented input stream.
-pub struct Segments<'r, R: Read, P: Parser> {
+pub struct Segments<'r, R, P> {
     reader: &'r mut Decoder<R>,
     state: State,
     parser: PhantomData<P>,
     unwrap: fn(Header) -> Result<Option<usize>, ()>,
 }
 
-impl<'r, R: Read, P: Parser> Segments<'r, R, P> {
+impl<'r, R, P> Segments<'r, R, P> {
     #[inline]
     pub(crate) fn new(
         decoder: &'r mut Decoder<R>,
@@ -189,7 +189,9 @@ impl<'r, R: Read, P: Parser> Segments<'r, R, P> {
             unwrap,
         }
     }
+}
 
+impl<'r, R: Read, P: Parser> Segments<'r, R, P> {
     /// Gets the next segment in the stream
     ///
     /// Returns `Ok(None)` at the conclusion of the stream.

--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -49,7 +49,7 @@ impl<E: de::Error> Expected<E> for Header {
 }
 
 /// Deserializer
-pub struct Deserializer<'b, R: Read> {
+pub struct Deserializer<'b, R> {
     decoder: Decoder<R>,
     scratch: &'b mut [u8],
     recurse: usize,
@@ -634,7 +634,7 @@ where
     }
 }
 
-struct Access<'a, 'b, R: Read>(&'a mut Deserializer<'b, R>, Option<usize>);
+struct Access<'a, 'b, R>(&'a mut Deserializer<'b, R>, Option<usize>);
 
 impl<'de, 'a, 'b, R: Read> de::SeqAccess<'de> for Access<'a, 'b, R>
 where
@@ -757,7 +757,7 @@ where
     }
 }
 
-struct BytesAccess<R: Read>(usize, Vec<u8>, core::marker::PhantomData<R>);
+struct BytesAccess<R>(usize, Vec<u8>, core::marker::PhantomData<R>);
 
 impl<'de, R: Read> de::SeqAccess<'de> for BytesAccess<R>
 where
@@ -787,7 +787,7 @@ where
     }
 }
 
-struct TagAccess<'a, 'b, R: Read>(&'a mut Deserializer<'b, R>, usize);
+struct TagAccess<'a, 'b, R>(&'a mut Deserializer<'b, R>, usize);
 
 impl<'de, 'a, 'b, R: Read> de::Deserializer<'de> for &mut TagAccess<'a, 'b, R>
 where

--- a/ciborium/src/ser/mod.rs
+++ b/ciborium/src/ser/mod.rs
@@ -12,7 +12,7 @@ use ciborium_io::Write;
 use ciborium_ll::*;
 use serde::{ser, Serialize as _};
 
-struct Serializer<W: Write>(Encoder<W>);
+struct Serializer<W>(Encoder<W>);
 
 impl<W: Write> From<W> for Serializer<W> {
     #[inline]
@@ -335,7 +335,7 @@ macro_rules! end {
     };
 }
 
-struct CollectionSerializer<'a, W: Write> {
+struct CollectionSerializer<'a, W> {
     encoder: &'a mut Serializer<W>,
     ending: bool,
     tag: bool,


### PR DESCRIPTION
This will allow future changes to enable zero copy deserialization to avoid more complicated bounds on various types.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
