### PR TITLE
fix: invalid allocation requests

### DIFF
--- a/ciborium/src/value/de.rs
+++ b/ciborium/src/value/de.rs
@@ -3,7 +3,7 @@
 use super::{Error, Integer, Value};
 
 use alloc::{boxed::Box, string::String, vec::Vec};
-use core::iter::Peekable;
+use core::{iter::Peekable, mem::size_of};
 
 use ciborium_ll::tag;
 use serde::de::{self, Deserializer as _};
@@ -124,7 +124,9 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
 
     #[inline]
     fn visit_map<A: de::MapAccess<'de>>(self, mut acc: A) -> Result<Self::Value, A::Error> {
-        let mut map = Vec::<(Value, Value)>::with_capacity(acc.size_hint().unwrap_or(0));
+        let mut map = Vec::<(Value, Value)>::with_capacity(
+            acc.size_hint().filter(|&l| l < 1024).unwrap_or(0),
+        );
 
         while let Some(kv) = acc.next_entry()? {
             map.push(kv);


### PR DESCRIPTION
Invalid data can lead to allocating too much memory. Only preallocate up to 1024 `Value` objects.

Fixes: #115

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
