### PR TITLE
feat: implement ser::to_vec() for convenient serializing into a new Vec<u8>

### DIFF
--- a/ciborium/src/lib.rs
+++ b/ciborium/src/lib.rs
@@ -107,6 +107,9 @@ pub use crate::de::from_reader_with_buffer;
 pub use crate::ser::into_writer;
 
 #[doc(inline)]
+pub use crate::ser::into_vec;
+
+#[doc(inline)]
 pub use crate::value::Value;
 
 /// Build a `Value` conveniently.

--- a/ciborium/src/ser/mod.rs
+++ b/ciborium/src/ser/mod.rs
@@ -497,3 +497,14 @@ where
     let mut encoder = Serializer::from(writer);
     value.serialize(&mut encoder)
 }
+
+/// Serializes as CBOR into a new Vec<u8>
+#[inline]
+pub fn into_vec<T: ?Sized + ser::Serialize>(
+    value: &T,
+) -> Result<Vec<u8>, Error<<Vec<u8> as ciborium_io::Write>::Error>> {
+    let mut vector = vec![];
+    let mut encoder = Serializer::from(&mut vector);
+    value.serialize(&mut encoder)?;
+    Ok(vector)
+}

--- a/ciborium/tests/codec.rs
+++ b/ciborium/tests/codec.rs
@@ -7,7 +7,9 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use ciborium::value::Value;
-use ciborium::{cbor, de::from_reader, de::from_reader_with_buffer, ser::into_writer};
+use ciborium::{
+    cbor, de::from_reader, de::from_reader_with_buffer, ser::into_vec, ser::into_writer,
+};
 
 use rstest::rstest;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -290,13 +292,11 @@ fn codec<'de, T: Serialize + Clone, V: Debug + PartialEq + DeserializeOwned, F: 
     let bytes = hex::decode(bytes).unwrap();
 
     if !alternate {
-        let mut encoded = Vec::new();
-        into_writer(&input, &mut encoded).unwrap();
+        let encoded = into_vec(&input).unwrap();
         eprintln!("{:x?} == {:x?}", bytes, encoded);
         assert_eq!(bytes, encoded);
 
-        let mut encoded = Vec::new();
-        into_writer(&value, &mut encoded).unwrap();
+        let encoded = into_vec(&value).unwrap();
         eprintln!("{:x?} == {:x?}", bytes, encoded);
         assert_eq!(bytes, encoded);
 


### PR DESCRIPTION
such shortcut is usually included in serde format libraries

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
