### PR TITLE
refactor: remove unused code from deserializer

### DIFF
--- a/ciborium/src/value/de.rs
+++ b/ciborium/src/value/de.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tag::TagAccess;
+
 use super::{Error, Integer, Value};
 
 use alloc::{boxed::Box, string::String, vec::Vec};
@@ -236,7 +238,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
 
             Value::Tag(t, v) => {
                 let parent: Deserializer<&Value> = Deserializer(v);
-                let access = crate::tag::TagAccess::new(parent, Some(*t));
+                let access = TagAccess::new(parent, Some(*t));
                 visitor.visit_enum(access)
             }
 
@@ -489,7 +491,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
             };
 
             let parent: Deserializer<&Value> = Deserializer(val);
-            let access = crate::tag::TagAccess::new(parent, tag);
+            let access = TagAccess::new(parent, tag);
             return visitor.visit_enum(access);
         }
 


### PR DESCRIPTION
The `TagAccess` type from the `ciborium::de` module seems to be unused.
Only the `crate::tag::TagAccess` is used.
So I removed it and replaced the qualified path `crate::tag::TagAccess` with a `use` import.

Additionally a header pull followed by a push was also removed, since it
1. didn't forward the decoder in any important way and
2. the pulled header wasn't actually used.