### PR TITLE
feat: implement ser::to_vec() for convenient serializing into a new Vec<u8>

### DIFF
--- a/ciborium/src/lib.rs
+++ b/ciborium/src/lib.rs
@@ -106,6 +106,10 @@ pub use crate::de::from_reader_with_buffer;
 #[doc(inline)]
 pub use crate::ser::into_writer;
 
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use crate::ser::into_vec;
+
 #[doc(inline)]
 pub use crate::value::Value;
 

--- a/ciborium/src/ser/mod.rs
+++ b/ciborium/src/ser/mod.rs
@@ -497,3 +497,15 @@ where
     let mut encoder = Serializer::from(writer);
     value.serialize(&mut encoder)
 }
+
+#[cfg(feature = "std")]
+/// Serializes as CBOR into a new Vec<u8>
+#[inline]
+pub fn into_vec<T: ?Sized + ser::Serialize>(
+    value: &T,
+) -> Result<Vec<u8>, Error<<Vec<u8> as ciborium_io::Write>::Error>> {
+    let mut vector = vec![];
+    let mut encoder = Serializer::from(&mut vector);
+    value.serialize(&mut encoder)?;
+    Ok(vector)
+}

--- a/ciborium/tests/codec.rs
+++ b/ciborium/tests/codec.rs
@@ -296,7 +296,7 @@ fn codec<'de, T: Serialize + Clone, V: Debug + PartialEq + DeserializeOwned, F: 
         assert_eq!(bytes, encoded);
 
         let mut encoded = Vec::new();
-        into_writer(&value, &mut encoded).unwrap();
+        into_writer(&input, &mut encoded).unwrap();
         eprintln!("{:x?} == {:x?}", bytes, encoded);
         assert_eq!(bytes, encoded);
 


### PR DESCRIPTION
Such shortcut is usually included in serde format libraries

refinement of #128