### PR TITLE
feat: simple type support

### DIFF
--- a/ciborium/src/lib.rs
+++ b/ciborium/src/lib.rs
@@ -94,6 +94,7 @@ extern crate alloc;
 
 pub mod de;
 pub mod ser;
+pub mod simple_type;
 pub mod tag;
 pub mod value;
 

--- a/ciborium/src/ser/mod.rs
+++ b/ciborium/src/ser/mod.rs
@@ -200,10 +200,21 @@ where
     #[inline]
     fn serialize_newtype_struct<U: ?Sized + ser::Serialize>(
         self,
-        _name: &'static str,
+        name: &'static str,
         value: &U,
     ) -> Result<(), Self::Error> {
-        value.serialize(self)
+        if name == "@@SIMPLETYPE@@" {
+            use serde::ser::Error as _;
+
+            let v = crate::Value::serialized(value).map_err(Error::custom)?;
+            let v = v
+                .as_integer()
+                .ok_or_else(|| Error::custom("Internal error handling simple types"))?;
+            let v = u8::try_from(v).map_err(Error::custom)?;
+            Ok(self.0.push(Header::Simple(v))?)
+        } else {
+            value.serialize(self)
+        }
     }
 
     #[inline]
@@ -214,7 +225,16 @@ where
         variant: &'static str,
         value: &U,
     ) -> Result<(), Self::Error> {
-        if name != "@@TAG@@" || variant != "@@UNTAGGED@@" {
+        if name == "@@ST@@" && variant == "@@SIMPLETYPE@@" {
+            use serde::ser::Error as _;
+
+            let v = crate::Value::serialized(value).map_err(Error::custom)?;
+            let v = v
+                .as_integer()
+                .ok_or_else(|| Error::custom("Internal error handling simple types"))?;
+            let v = u8::try_from(v).map_err(Error::custom)?;
+            return Ok(self.0.push(Header::Simple(v))?);
+        } else if name != "@@TAG@@" || variant != "@@UNTAGGED@@" {
             self.0.push(Header::Map(Some(1)))?;
             self.serialize_str(variant)?;
         }

--- a/ciborium/src/simple_type.rs
+++ b/ciborium/src/simple_type.rs
@@ -1,0 +1,141 @@
+//! Contains helper types for dealing with CBOR simple types
+
+use serde::{de, de::Error as _, forward_to_deserialize_any, ser, Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename = "@@ST@@")]
+enum Internal {
+    /// The integer can either be 23, or (32..=255)
+    #[serde(rename = "@@SIMPLETYPE@@")]
+    SimpleType(u8),
+}
+
+/// A CBOR simple value
+/// See https://datatracker.ietf.org/doc/html/rfc8949#section-3.3
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SimpleType(pub u8);
+
+impl<'de> Deserialize<'de> for SimpleType {
+    #[inline]
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match Internal::deserialize(deserializer)? {
+            Internal::SimpleType(t) => Ok(SimpleType(t)),
+        }
+    }
+}
+
+impl Serialize for SimpleType {
+    #[inline]
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Internal::SimpleType(self.0).serialize(serializer)
+    }
+}
+
+pub(crate) struct SimpleTypeAccess<D> {
+    parent: Option<D>,
+    state: usize,
+    typ: u8,
+}
+
+impl<D> SimpleTypeAccess<D> {
+    pub fn new(parent: D, typ: u8) -> Self {
+        Self {
+            parent: Some(parent),
+            state: 0,
+            typ,
+        }
+    }
+}
+
+impl<'de, D: de::Deserializer<'de>> de::Deserializer<'de> for &mut SimpleTypeAccess<D> {
+    type Error = D::Error;
+
+    #[inline]
+    fn deserialize_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.state += 1;
+        match self.state {
+            1 => visitor.visit_str("@@SIMPLETYPE@@"),
+            _ => visitor.visit_u8(self.typ),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        i8 i16 i32 i64 i128
+        u8 u16 u32 u64 u128
+        bool f32 f64
+        char str string
+        bytes byte_buf
+        seq map
+        struct tuple tuple_struct
+        identifier ignored_any
+        option unit unit_struct newtype_struct enum
+    }
+}
+
+impl<'de, D: de::Deserializer<'de>> de::EnumAccess<'de> for SimpleTypeAccess<D> {
+    type Error = D::Error;
+    type Variant = Self;
+
+    #[inline]
+    fn variant_seed<V: de::DeserializeSeed<'de>>(
+        mut self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Self::Error> {
+        let variant = seed.deserialize(&mut self)?;
+        Ok((variant, self))
+    }
+}
+
+impl<'de, D: de::Deserializer<'de>> de::VariantAccess<'de> for SimpleTypeAccess<D> {
+    type Error = D::Error;
+
+    #[inline]
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Err(Self::Error::custom("expected simple type"))
+    }
+
+    #[inline]
+    fn newtype_variant_seed<U: de::DeserializeSeed<'de>>(
+        mut self,
+        seed: U,
+    ) -> Result<U::Value, Self::Error> {
+        seed.deserialize(self.parent.take().unwrap())
+    }
+
+    #[inline]
+    fn tuple_variant<V: de::Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_seq(self)
+    }
+
+    #[inline]
+    fn struct_variant<V: de::Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(Self::Error::custom("expected simple_type"))
+    }
+}
+
+impl<'de, D: de::Deserializer<'de>> de::SeqAccess<'de> for SimpleTypeAccess<D> {
+    type Error = D::Error;
+
+    #[inline]
+    fn next_element_seed<T: de::DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        if self.state < 2 {
+            return Ok(Some(seed.deserialize(self)?));
+        }
+
+        Ok(match self.parent.take() {
+            Some(x) => Some(seed.deserialize(x)?),
+            None => None,
+        })
+    }
+}

--- a/ciborium/src/value/de.rs
+++ b/ciborium/src/value/de.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::tag::TagAccess;
+use crate::{simple_type::SimpleTypeAccess, tag::TagAccess};
 
 use super::{Error, Integer, Value};
 
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::iter::Peekable;
 
-use ciborium_ll::tag;
+use ciborium_ll::{simple, tag};
 use serde::de::{self, Deserializer as _};
 
 impl<'a> From<Integer> for de::Unexpected<'a> {
@@ -36,6 +36,7 @@ impl<'a> From<&'a Value> for de::Unexpected<'a> {
             Value::Map(..) => Self::Map,
             Value::Null => Self::Other("null"),
             Value::Tag(..) => Self::Other("tag"),
+            Value::Simple(..) => Self::Other("simple"),
         }
     }
 }
@@ -141,9 +142,9 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
     fn visit_enum<A: de::EnumAccess<'de>>(self, acc: A) -> Result<Self::Value, A::Error> {
         use serde::de::VariantAccess;
 
-        struct Inner;
+        struct TagInner;
 
-        impl<'de> serde::de::Visitor<'de> for Inner {
+        impl<'de> serde::de::Visitor<'de> for TagInner {
             type Value = Value;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -162,9 +163,30 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
             }
         }
 
+        struct SimpleTypeInner;
+
+        impl<'de> serde::de::Visitor<'de> for SimpleTypeInner {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(formatter, "a valid CBOR item")
+            }
+
+            #[inline]
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut acc: A) -> Result<Self::Value, A::Error> {
+                let st = acc
+                    .next_element::<u8>()?
+                    .ok_or_else(|| de::Error::custom("expected simple type"))?;
+                Ok(Value::Simple(st))
+            }
+        }
+
         let (name, data): (String, _) = acc.variant()?;
-        assert_eq!("@@TAGGED@@", name);
-        data.tuple_variant(2, Inner)
+        match name.as_str() {
+            "@@TAGGED@@" => data.tuple_variant(2, TagInner),
+            "@@SIMPLETYPE@@" => data.tuple_variant(1, SimpleTypeInner),
+            _ => panic!("Implementation error"),
+        }
     }
 }
 
@@ -218,6 +240,7 @@ impl<'a> Deserializer<&'a Value> {
                 .map(|x| x ^ !0)
                 .map_err(|_| err())
                 .and_then(|x| x.try_into().map_err(|_| err()))?,
+            Value::Simple(x) => i128::from(*x).try_into().map_err(|_| err())?,
             _ => return Err(de::Error::invalid_type(self.0.into(), &"(big)int")),
         })
     }
@@ -228,6 +251,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
 
     #[inline]
     fn deserialize_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        use serde::ser::Error as _;
         match self.0 {
             Value::Bytes(x) => visitor.visit_bytes(x),
             Value::Text(x) => visitor.visit_str(x),
@@ -235,6 +259,14 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
             Value::Map(x) => visitor.visit_map(Deserializer(x.iter().peekable())),
             Value::Bool(x) => visitor.visit_bool(*x),
             Value::Null => visitor.visit_none(),
+            Value::Simple(v @ simple::UNDEFINED) => {
+                visitor.visit_enum(SimpleTypeAccess::new(self, *v))
+            }
+            Value::Simple(0..=31) => Err(Self::Error::custom("Unsupported simple type")),
+            Value::Simple(v) => {
+                let access = SimpleTypeAccess::new(self, *v);
+                visitor.visit_enum(access)
+            }
 
             Value::Tag(t, v) => {
                 let parent: Deserializer<&Value> = Deserializer(v);
@@ -493,6 +525,18 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
             let parent: Deserializer<&Value> = Deserializer(val);
             let access = TagAccess::new(parent, tag);
             return visitor.visit_enum(access);
+        } else if name == "@@ST@@" {
+            use serde::ser::Error as _;
+            return match self.0 {
+                Value::Simple(v @ simple::UNDEFINED) => {
+                    visitor.visit_enum(SimpleTypeAccess::new(Deserializer(self.0), *v))
+                }
+                Value::Simple(0..=31) => return Err(Error::custom("Unsupported simple type")),
+                Value::Simple(v) => {
+                    visitor.visit_enum(SimpleTypeAccess::new(Deserializer(self.0), *v))
+                }
+                _ => Err(Error::custom("Implementation error for simple type")),
+            };
         }
 
         match self.0 {

--- a/ciborium/src/value/mod.rs
+++ b/ciborium/src/value/mod.rs
@@ -45,6 +45,9 @@ pub enum Value {
 
     /// A map
     Map(Vec<(Value, Value)>),
+
+    /// A CBOR "Simple Value" other than true, false, or null
+    Simple(u8),
 }
 
 impl Value {
@@ -591,6 +594,47 @@ impl Value {
     pub fn into_map(self) -> Result<Vec<(Value, Value)>, Self> {
         match self {
             Value::Map(map) => Ok(map),
+            other => Err(other),
+        }
+    }
+
+    /// Returns true if the `Value` is an `SimpleType`. Returns false otherwise.
+    ///
+    /// ```
+    /// # use ciborium::Value;
+    /// #
+    /// assert!(Value::Simple(59).is_simple());
+    /// ```
+    pub fn is_simple(&self) -> bool {
+        self.as_simple().is_some()
+    }
+
+    /// If the `Value` is a `SimpleType`. The value can only be in [0..23] or [32..255].
+    ///
+    /// ```
+    /// # use ciborium::Value;
+    /// #
+    /// assert_eq!(59, Value::Simple(59).as_simple().unwrap());
+    /// ```
+    pub fn as_simple(&self) -> Option<u8> {
+        match self {
+            Value::Simple(int) => Some(*int),
+            _ => None,
+        }
+    }
+
+    /// If the `Value` is a `SimpleType`. The value can only be in [0..23] or [32..255].
+    ///
+    /// ```
+    /// # use ciborium::{Value, value::Integer};
+    /// #
+    /// assert_eq!(Value::Simple(59).into_simple(), Ok(59));
+    ///
+    /// assert_eq!(Value::Bool(true).into_simple(), Err(Value::Bool(true)));
+    /// ```
+    pub fn into_simple(self) -> Result<u8, Self> {
+        match self {
+            Value::Simple(int) => Ok(int),
             other => Err(other),
         }
     }

--- a/ciborium/tests/simple_type.rs
+++ b/ciborium/tests/simple_type.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate alloc;
+
+use ciborium::{de::from_reader, ser::into_writer, simple_type::SimpleType, value::Value};
+use rstest::rstest;
+use serde::{de::DeserializeOwned, Serialize};
+
+use core::fmt::Debug;
+use std::collections::HashMap;
+
+#[rstest(item, bytes, value, encode, success,
+      case(SimpleType(0), "e0", Value::Simple(0), true, false), // Registered via Standard Actions
+      case(SimpleType(19), "f3", Value::Simple(19), true, false), // Registered via Standard Actions
+      case(SimpleType(23), "f7", Value::Simple(23), true, true), // CBOR simple value "undefined"
+      case(SimpleType(32), "f820", Value::Simple(32), true, true),
+      case(SimpleType(59), "f83b", Value::Simple(59), true, true),
+      case(SimpleType(255), "f8ff", Value::Simple(255), true, true),
+      case(vec![SimpleType(255)], "81f8ff", Value::Array(vec![Value::Simple(255)]), true, true),
+      case(HashMap::<SimpleType, u8>::from_iter([(SimpleType(59), 0)]), "a1f83b00", Value::Map(vec![(Value::Simple(59), Value::Integer(0.into()))]), true, true),
+)]
+fn test<T: Serialize + DeserializeOwned + Debug + Eq>(
+    item: T,
+    bytes: &str,
+    value: Value,
+    encode: bool,
+    success: bool,
+) {
+    let bytes = hex::decode(bytes).unwrap();
+
+    if encode {
+        // Encode into bytes
+        let mut encoded = Vec::new();
+        into_writer(&item, &mut encoded).unwrap();
+        assert_eq!(bytes, encoded);
+
+        // Encode into value
+        assert_eq!(value, Value::serialized(&item).unwrap());
+    }
+
+    // Decode from bytes
+    match from_reader(&bytes[..]) {
+        Ok(x) if success => assert_eq!(item, x),
+        Ok(..) => panic!("unexpected success"),
+        Err(e) if success => panic!("{:?}", e),
+        Err(..) => (),
+    }
+
+    // Decode from value
+    match value.deserialized() {
+        Ok(x) if success => assert_eq!(item, x),
+        Ok(..) => panic!("unexpected success"),
+        Err(e) if success => panic!("{:?}", e),
+        Err(..) => (),
+    }
+}
+
+#[test]
+fn value_serialized() {
+    let st = Value::Simple(59);
+    assert_eq!(st.clone(), Value::serialized(&st).unwrap());
+
+    let map_as_key = Value::Map(vec![(st.clone(), Value::Integer(0.into()))]);
+    assert_eq!(map_as_key, Value::serialized(&map_as_key).unwrap());
+
+    let map_as_value = Value::Map(vec![(Value::Integer(0.into()), st.clone())]);
+    assert_eq!(map_as_value, Value::serialized(&map_as_value).unwrap());
+
+    let array = Value::Array(vec![st]);
+    assert_eq!(array, Value::serialized(&array).unwrap());
+}
+
+#[test]
+fn value_deserialize() {
+    let st = Value::Simple(59);
+
+    let in_map_as_label = Value::Map(vec![(st.clone(), Value::Integer(0.into()))]);
+    Value::deserialized::<Value>(&in_map_as_label).unwrap();
+
+    let in_map_as_value = Value::Map(vec![(Value::Integer(0.into()), st.clone())]);
+    Value::deserialized::<Value>(&in_map_as_value).unwrap();
+
+    let in_array = Value::Array(vec![st.clone()]);
+    Value::deserialized::<Value>(&in_array).unwrap();
+}
+
+#[test]
+fn should_roundtrip() {
+    let st = Value::Simple(59);
+
+    let map = Value::Map(vec![(st.clone(), Value::Array(vec![]))]);
+
+    let mut encoded = vec![];
+    into_writer(&map, &mut encoded).unwrap();
+
+    let decoded = from_reader::<Value, _>(&encoded[..]).unwrap();
+    assert_eq!(decoded, map);
+}


### PR DESCRIPTION
Hi, 

I've crated this PR to add support for CBOR Simple types as defined in [RFC 8949 Section 3.3](https://www.rfc-editor.org/rfc/rfc8949.html#section-3.3).

I've roughly used the same approach you used for tags. I chose to fail in case a reserved simple type was used (0..=19) or (24..=31) and I think this is what causes the fuzzer to fail. He also seems not to differentiate one-byte and two-byte variants of simple types which causes some other errors in the fuzzer. I would like some pointers from your side to understand what happens under the hood and how to fix that.

Additionally, I wanted to take advantage of this PR to introduce a new variant `Value::Undefined` instead of `Value::Simple(23)`. I think that's fine since the enum in `#[non_exhaustive]`. Let me know if that sounds reasonable to you.

Any help getting this PR fixed and merged will be very appreciated :) 

Thank you

Closes #60 
