### PR TITLE
Aggressive inlining (+20% serialization speed boost)

### DIFF
--- a/ciborium-ll/src/enc.rs
+++ b/ciborium-ll/src/enc.rs
@@ -18,10 +18,12 @@ impl<W: Write> From<W> for Encoder<W> {
 impl<W: Write> Write for Encoder<W> {
     type Error = W::Error;
 
+    #[inline]
     fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         self.0.write_all(data)
     }
 
+    #[inline]
     fn flush(&mut self) -> Result<(), Self::Error> {
         self.0.flush()
     }
@@ -29,12 +31,13 @@ impl<W: Write> Write for Encoder<W> {
 
 impl<W: Write> Encoder<W> {
     /// Unwraps the `Write`, consuming the `Encoder`.
+    #[inline]
     pub fn into_inner(self) -> W {
         self.0
     }
 
     /// Push a `Header` to the wire
-    #[inline]
+    #[inline(always)]
     pub fn push(&mut self, header: Header) -> Result<(), W::Error> {
         let title = Title::from(header);
 

--- a/ciborium-ll/src/hdr.rs
+++ b/ciborium-ll/src/hdr.rs
@@ -75,6 +75,7 @@ pub enum Header {
 impl TryFrom<Title> for Header {
     type Error = InvalidError;
 
+    #[inline]
     fn try_from(title: Title) -> Result<Self, Self::Error> {
         let opt = |minor| {
             Some(match minor {
@@ -116,6 +117,7 @@ impl TryFrom<Title> for Header {
 }
 
 impl From<Header> for Title {
+    #[inline(always)]
     fn from(header: Header) -> Self {
         let int = |i: u64| match i {
             x if x <= 23 => Minor::This(i as u8),


### PR DESCRIPTION
This PR adds a roughly 20% speed improvement to serialization in my application benchmarks. 

The use of `#[inline(always)]` is required because LLVM sees the function as "large" and avoids inlining a plain `#[inline]` hint. However, almost all usage of these methods in ciborium specify the enum at compile-time, which means this "large" function can be optimised to a small set of instructions and remove many branches.

I could add a `ciborium-bench` crate into the workspace using criterion to demonstrate this if this change is likely to be accepted? Cheers!

---

One minor concern is compiling with opt_level `s` or `z`, where application developers may prefer a smaller bundle size (such as WASM use cases). We could use a `smaller-bundle` feature flag for this case, and use `#[cfg_attr(not(feature = "smaller-bundle"), inline(always)]` instead. The binary bloat is likely minor though.