### PR TITLE
Implement `from_slice` deserialization and criterion benchmarks

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+allowed-duplicate-crates = ["syn"]

--- a/ciborium-io/README.md
+++ b/ciborium-io/README.md
@@ -1,7 +1,7 @@
 [![Workflow Status](https://github.com/enarx/ciborium/workflows/test/badge.svg)](https://github.com/enarx/ciborium/actions?query=workflow%3A%22test%22)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/ciborium.svg)](https://isitmaintained.com/project/enarx/ciborium "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/ciborium.svg)](https://isitmaintained.com/project/enarx/ciborium "Percentage of issues still open")
-![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
+![Maintenance](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 # ciborium-io
 

--- a/ciborium-io/src/lib.rs
+++ b/ciborium-io/src/lib.rs
@@ -22,6 +22,9 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+pub mod slice;
+pub use slice::{EndOfSliceError, SliceReader};
+
 /// Adapters of embedded-io::{Read, Write} implementing ciborium::{Read, Write}
 #[cfg(feature = "embedded-io")]
 pub mod eio;

--- a/ciborium-io/src/slice.rs
+++ b/ciborium-io/src/slice.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slice-backed reader utilities.
+
+use core::cmp;
+
+/// Error returned when attempting to read past the end of a slice.
+#[cfg(feature = "std")]
+pub type EndOfSliceError = std::io::Error;
+
+/// Error returned when attempting to read past the end of a slice.
+#[cfg(not(feature = "std"))]
+/// Error returned when attempting to read past the end of a slice.
+#[derive(Clone, Debug)]
+pub struct EndOfSliceError(());
+
+/// A reader that wraps a byte slice with a lifetime, enabling zero-copy deserialization.
+///
+/// This reader keeps track of the original slice and the current cursor so that other
+/// components can create borrowed subslices without copying.
+pub struct SliceReader<'de> {
+    data: &'de [u8],
+    cursor: usize,
+}
+
+impl<'de> SliceReader<'de> {
+    /// Creates a new `SliceReader` from a byte slice.
+    #[inline]
+    pub fn new(slice: &'de [u8]) -> Self {
+        Self { data: slice, cursor: 0 }
+    }
+
+    /// Advances the reader by `len` bytes without copying them anywhere.
+    ///
+    /// Callers must ensure that `len` does not exceed the remaining slice length.
+    #[inline]
+    pub fn skip(&mut self, len: usize) {
+        debug_assert!(len <= self.remaining_len());
+        self.cursor += len;
+    }
+
+    /// Returns the number of unread bytes left in the slice.
+    #[inline]
+    pub fn remaining_len(&self) -> usize {
+        self.data.len().saturating_sub(self.cursor)
+    }
+
+    /// Returns true if the provided range lies within the source slice.
+    #[inline]
+    pub fn contains_range(&self, start: usize, len: usize) -> bool {
+        start
+            .checked_add(len)
+            .map_or(false, |end| end <= self.data.len())
+    }
+
+    /// Returns the requested subslice without advancing the cursor.
+    ///
+    /// Callers must ensure the requested range lies within the original data.
+    #[inline]
+    pub fn slice_at(&self, start: usize, len: usize) -> &'de [u8] {
+        &self.data[start..start + len]
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'de> std::io::Read for SliceReader<'de> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let remaining = &self.data[self.cursor..];
+        let to_read = cmp::min(buf.len(), remaining.len());
+        buf[..to_read].copy_from_slice(&remaining[..to_read]);
+        self.cursor += to_read;
+        Ok(to_read)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<'de> crate::Read for SliceReader<'de> {
+    type Error = EndOfSliceError;
+
+    #[inline]
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), EndOfSliceError> {
+        if data.len() > self.remaining_len() {
+            return Err(EndOfSliceError(()));
+        }
+        let end = self.cursor + data.len();
+        data.copy_from_slice(&self.data[self.cursor..end]);
+        self.cursor = end;
+        Ok(())
+    }
+}

--- a/ciborium-io/src/slice.rs
+++ b/ciborium-io/src/slice.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Slice-backed reader utilities.
+
+/// Error returned when attempting to read past the end of a slice.
+#[cfg(feature = "std")]
+pub type EndOfSliceError = std::io::Error;
+
+/// Error returned when attempting to read past the end of a slice.
+#[cfg(not(feature = "std"))]
+/// Error returned when attempting to read past the end of a slice.
+#[derive(Clone, Debug)]
+pub struct EndOfSliceError(());
+
+/// A reader that wraps a byte slice with a lifetime, enabling zero-copy deserialization.
+///
+/// The unread portion is retained as a subslice, allowing bytes to be consumed or
+/// borrowed with a single bounds check.
+pub struct SliceReader<'de> {
+    remaining: &'de [u8],
+}
+
+impl<'de> SliceReader<'de> {
+    /// Creates a new `SliceReader` from a byte slice.
+    #[inline]
+    pub fn new(slice: &'de [u8]) -> Self {
+        Self { remaining: slice }
+    }
+
+    /// Takes the next `len` bytes without copying them.
+    #[inline]
+    pub fn take(&mut self, len: usize) -> Option<&'de [u8]> {
+        if len > self.remaining.len() {
+            return None;
+        }
+
+        let (prefix, suffix) = self.remaining.split_at(len);
+        self.remaining = suffix;
+        Some(prefix)
+    }
+
+    /// Returns the number of unread bytes left in the slice.
+    #[inline]
+    pub fn remaining_len(&self) -> usize {
+        self.remaining.len()
+    }
+}
+
+impl<'de> crate::Read for SliceReader<'de> {
+    type Error = EndOfSliceError;
+
+    #[inline]
+    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), EndOfSliceError> {
+        match self.take(data.len()) {
+            Some(source) => {
+                data.copy_from_slice(source);
+                Ok(())
+            }
+            #[cfg(feature = "std")]
+            None => Err(std::io::ErrorKind::UnexpectedEof.into()),
+            #[cfg(not(feature = "std"))]
+            None => Err(EndOfSliceError(())),
+        }
+    }
+}

--- a/ciborium-ll/README.md
+++ b/ciborium-ll/README.md
@@ -1,7 +1,7 @@
 [![Workflow Status](https://github.com/enarx/ciborium/workflows/test/badge.svg)](https://github.com/enarx/ciborium/actions?query=workflow%3A%22test%22)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/ciborium.svg)](https://isitmaintained.com/project/enarx/ciborium "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/ciborium.svg)](https://isitmaintained.com/project/enarx/ciborium "Percentage of issues still open")
-![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
+![Maintenance](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 # ciborium-ll
 

--- a/ciborium-ll/src/dec.rs
+++ b/ciborium-ll/src/dec.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-use ciborium_io::Read;
+use ciborium_io::{slice::SliceReader, Read};
 
 /// An error that occurred while decoding
 #[derive(Clone, Debug)]
@@ -134,6 +134,16 @@ impl<R: Read> Decoder<R> {
         self.offset
     }
 
+    /// Advances the tracked byte offset without performing any reads.
+    ///
+    /// This should be used only when bytes have been consumed by other means
+    /// (for example, by reusing an underlying slice) so that future error
+    /// messages report the correct position.
+    #[inline]
+    pub fn bump_offset(&mut self, len: usize) {
+        self.offset += len;
+    }
+
     /// Process an incoming bytes item
     ///
     /// In CBOR, bytes can be segmented. The logic for this can be a bit tricky,
@@ -172,5 +182,20 @@ impl<R: Read> Decoder<R> {
             Header::Text(len) => Ok(len),
             _ => Err(()),
         })
+    }
+}
+
+impl<'slice> Decoder<&mut SliceReader<'slice>> {
+    /// Attempts to borrow the next `len` bytes directly from the underlying slice.
+    #[inline]
+    pub fn try_borrow_slice(&mut self, len: usize) -> Option<&'slice [u8]> {
+        let start = self.offset;
+        if self.reader.contains_range(start, len) {
+            self.reader.skip(len);
+            self.offset += len;
+            Some(self.reader.slice_at(start, len))
+        } else {
+            None
+        }
     }
 }

--- a/ciborium-ll/src/dec.rs
+++ b/ciborium-ll/src/dec.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-use ciborium_io::Read;
+use ciborium_io::{slice::SliceReader, Read};
 
 /// An error that occurred while decoding
 #[derive(Clone, Debug)]
@@ -172,5 +172,17 @@ impl<R: Read> Decoder<R> {
             Header::Text(len) => Ok(len),
             _ => Err(()),
         })
+    }
+}
+
+impl<'slice> Decoder<SliceReader<'slice>> {
+    /// Attempts to borrow the next `len` bytes directly from the underlying slice.
+    #[inline]
+    pub fn try_borrow_slice(&mut self, len: usize) -> Option<&'slice [u8]> {
+        let slice = self.reader.take(len);
+        if slice.is_some() {
+            self.offset += len;
+        }
+        slice
     }
 }

--- a/ciborium/Cargo.toml
+++ b/ciborium/Cargo.toml
@@ -26,10 +26,11 @@ ciborium-io = { path = "../ciborium-io", version = "0.2.2", features = ["alloc"]
 serde = { version = "1.0.170", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-serde_bytes = "0.11"
-rstest = "0.26"
-rand = "0.9"
+criterion = "0.8"
 hex = "0.4"
+rand = "0.9"
+rstest = "0.26"
+serde_bytes = "0.11"
 
 [features]
 default = ["std"]
@@ -37,3 +38,7 @@ std = ["ciborium-io/std", "serde/std"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "serde"
+harness = false

--- a/ciborium/Cargo.toml
+++ b/ciborium/Cargo.toml
@@ -26,10 +26,11 @@ ciborium-io = { path = "../ciborium-io", version = "0.2.2", features = ["alloc"]
 serde = { version = "1.0.170", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-serde_bytes = "0.11"
-rstest = "0.26"
-rand = "0.9"
+criterion = "0.7"
 hex = "0.4"
+rand = "0.9"
+rstest = "0.26"
+serde_bytes = "0.11"
 
 [features]
 default = ["std"]
@@ -37,3 +38,7 @@ std = ["ciborium-io/std", "serde/std"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "serde"
+harness = false

--- a/ciborium/README.md
+++ b/ciborium/README.md
@@ -1,7 +1,7 @@
 [![Workflow Status](https://github.com/enarx/ciborium/workflows/test/badge.svg)](https://github.com/enarx/ciborium/actions?query=workflow%3A%22test%22)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/ciborium.svg)](https://isitmaintained.com/project/enarx/ciborium "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/ciborium.svg)](https://isitmaintained.com/project/enarx/ciborium "Percentage of issues still open")
-![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
+![Maintenance](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 # ciborium
 

--- a/ciborium/benches/serde.rs
+++ b/ciborium/benches/serde.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::io::Cursor;
+
+use ciborium::{de::from_reader, from_slice, ser::into_writer};
+use criterion::{criterion_group, criterion_main, Criterion};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SampleDocument {
+    version: u16,
+    device: String,
+    active: bool,
+    tags: Vec<String>,
+    metadata: BTreeMap<String, i64>,
+    entries: Vec<SensorEntry>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SensorEntry {
+    id: u32,
+    label: String,
+    #[serde(with = "serde_bytes")]
+    payload: Vec<u8>,
+    readings: Vec<f64>,
+    comment: Option<String>,
+    states: [bool; 4],
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SampleDocumentBorrow<'a> {
+    version: u16,
+    #[serde(borrow)]
+    device: &'a str,
+    active: bool,
+    #[serde(borrow)]
+    tags: Vec<&'a str>,
+    metadata: BTreeMap<String, i64>,
+    entries: Vec<SensorEntryBorrow<'a>>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SensorEntryBorrow<'a> {
+    id: u32,
+    #[serde(borrow)]
+    label: &'a str,
+    payload: &'a [u8],
+    readings: Vec<f64>,
+    #[serde(borrow)]
+    comment: Option<&'a str>,
+    states: [bool; 4],
+}
+
+fn sample_document() -> SampleDocument {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("alpha".into(), 2);
+    metadata.insert("beta".into(), 8);
+    metadata.insert("gamma".into(), 13);
+    metadata.insert("delta".into(), 21);
+
+    let entries = (0..32)
+        .map(|idx| SensorEntry {
+            id: idx,
+            label: format!("sensor-{idx:02}"),
+            payload: (0..64)
+                .map(|offset| ((idx * 13 + offset) % 255) as u8)
+                .collect(),
+            readings: (0..8)
+                .map(|offset| (idx * 100 + offset) as f64 * 0.125)
+                .collect(),
+            comment: if idx % 3 == 0 {
+                Some(format!("reading {idx} is nominal"))
+            } else {
+                None
+            },
+            states: [
+                idx % 2 == 0,
+                idx % 3 == 0,
+                idx % 5 == 0,
+                idx % 7 == 0,
+            ],
+        })
+        .collect();
+
+    SampleDocument {
+        version: 2,
+        device: "env-sensor".into(),
+        active: true,
+        tags: vec!["bench".into(), "serde".into(), "cbor".into()],
+        metadata,
+        entries,
+    }
+}
+
+fn serialize_benchmark(c: &mut Criterion) {
+    let document = sample_document();
+    let mut scratch = Vec::new();
+    into_writer(&document, &mut scratch).expect("seed serialization");
+
+    c.bench_function("into_writer", |b| {
+        let mut buffer = Vec::with_capacity(scratch.len());
+        b.iter(|| {
+            buffer.clear();
+            into_writer(black_box(&document), &mut buffer).expect("serialize document");
+            black_box(buffer.len())
+        });
+    });
+}
+
+fn deserialize_benchmark(c: &mut Criterion) {
+    let document = sample_document();
+    let encoded = {
+        let mut buffer = Vec::new();
+        into_writer(&document, &mut buffer).expect("seed serialization");
+        buffer
+    };
+
+    c.bench_function("from_reader", |b| {
+        b.iter(|| {
+            let cursor = Cursor::new(black_box(encoded.as_slice()));
+            let decoded: SampleDocument =
+                from_reader(cursor).expect("deserialize sample document");
+            black_box(decoded.active)
+        });
+    });
+
+    c.bench_function("from_slice", |b| {
+        b.iter(|| {
+            let decoded: SampleDocument =
+                from_slice(black_box(encoded.as_slice())).expect("deserialize sample document");
+            black_box(decoded.active)
+        });
+    });
+
+    c.bench_function("from_slice_borrowed", |b| {
+        b.iter(|| {
+            let decoded: SampleDocumentBorrow<'_> =
+                from_slice(black_box(encoded.as_slice())).expect("deserialize sample document");
+            black_box(decoded.active)
+        });
+    });
+}
+
+criterion_group!(serde, serialize_benchmark, deserialize_benchmark);
+criterion_main!(serde);

--- a/ciborium/benches/serde.rs
+++ b/ciborium/benches/serde.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::io::Cursor;
+
+use ciborium::{de::from_reader, from_slice, ser::into_writer};
+use criterion::{criterion_group, criterion_main, Criterion};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SampleDocument {
+    version: u16,
+    device: String,
+    active: bool,
+    tags: Vec<String>,
+    metadata: BTreeMap<String, i64>,
+    entries: Vec<SensorEntry>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SensorEntry {
+    id: u32,
+    label: String,
+    #[serde(with = "serde_bytes")]
+    payload: Vec<u8>,
+    readings: Vec<f64>,
+    comment: Option<String>,
+    states: [bool; 4],
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SampleDocumentBorrow<'a> {
+    version: u16,
+    #[serde(borrow)]
+    device: &'a str,
+    active: bool,
+    #[serde(borrow)]
+    tags: Vec<&'a str>,
+    metadata: BTreeMap<String, i64>,
+    entries: Vec<SensorEntryBorrow<'a>>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct SensorEntryBorrow<'a> {
+    id: u32,
+    #[serde(borrow)]
+    label: &'a str,
+    payload: &'a [u8],
+    readings: Vec<f64>,
+    #[serde(borrow)]
+    comment: Option<&'a str>,
+    states: [bool; 4],
+}
+
+fn sample_document() -> SampleDocument {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("alpha".into(), 2);
+    metadata.insert("beta".into(), 8);
+    metadata.insert("gamma".into(), 13);
+    metadata.insert("delta".into(), 21);
+
+    let entries = (0..32)
+        .map(|idx| SensorEntry {
+            id: idx,
+            label: format!("sensor-{idx:02}"),
+            payload: (0..64)
+                .map(|offset| ((idx * 13 + offset) % 255) as u8)
+                .collect(),
+            readings: (0..8)
+                .map(|offset| (idx * 100 + offset) as f64 * 0.125)
+                .collect(),
+            comment: if idx % 3 == 0 {
+                Some(format!("reading {idx} is nominal"))
+            } else {
+                None
+            },
+            states: [idx % 2 == 0, idx % 3 == 0, idx % 5 == 0, idx % 7 == 0],
+        })
+        .collect();
+
+    SampleDocument {
+        version: 2,
+        device: "env-sensor".into(),
+        active: true,
+        tags: vec!["bench".into(), "serde".into(), "cbor".into()],
+        metadata,
+        entries,
+    }
+}
+
+fn serialize_benchmark(c: &mut Criterion) {
+    let document = sample_document();
+    let mut scratch = Vec::new();
+    into_writer(&document, &mut scratch).expect("seed serialization");
+
+    c.bench_function("into_writer", |b| {
+        let mut buffer = Vec::with_capacity(scratch.len());
+        b.iter(|| {
+            buffer.clear();
+            into_writer(black_box(&document), &mut buffer).expect("serialize document");
+            black_box(buffer.len())
+        });
+    });
+}
+
+fn deserialize_benchmark(c: &mut Criterion) {
+    let document = sample_document();
+    let encoded = {
+        let mut buffer = Vec::new();
+        into_writer(&document, &mut buffer).expect("seed serialization");
+        buffer
+    };
+
+    c.bench_function("from_reader", |b| {
+        b.iter(|| {
+            let cursor = Cursor::new(black_box(encoded.as_slice()));
+            let decoded: SampleDocument = from_reader(cursor).expect("deserialize sample document");
+            black_box(decoded.active)
+        });
+    });
+
+    c.bench_function("from_slice", |b| {
+        b.iter(|| {
+            let decoded: SampleDocument =
+                from_slice(black_box(encoded.as_slice())).expect("deserialize sample document");
+            black_box(decoded.active)
+        });
+    });
+
+    c.bench_function("from_slice_borrowed", |b| {
+        b.iter(|| {
+            let decoded: SampleDocumentBorrow<'_> =
+                from_slice(black_box(encoded.as_slice())).expect("deserialize sample document");
+            black_box(decoded.active)
+        });
+    });
+}
+
+criterion_group!(serde, serialize_benchmark, deserialize_benchmark);
+criterion_main!(serde);

--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -8,11 +8,10 @@ pub use error::Error;
 
 use alloc::{string::String, vec::Vec};
 
-use ciborium_io::Read;
+use crate::tag::TagAccess;
+use ciborium_io::{EndOfSliceError, Read, SliceReader};
 use ciborium_ll::*;
 use serde::de::{self, value::BytesDeserializer, Deserializer as _};
-
-use crate::tag::TagAccess;
 
 trait Expected<E: de::Error> {
     fn expected(self, kind: &'static str) -> E;
@@ -48,15 +47,61 @@ impl<E: de::Error> Expected<E> for Header {
 }
 
 /// Deserializer
-pub struct Deserializer<'b, R> {
+pub struct Deserializer<'slice, 'b, R> {
     decoder: Decoder<R>,
     scratch: &'b mut [u8],
     recurse: usize,
+    borrow: BorrowSource<'slice, R>,
+}
+
+enum ByteSource<'slice> {
+    Borrowed(&'slice [u8]),
+    Scratch(usize),
+}
+
+type BorrowFn<'slice, R> = fn(&mut Decoder<R>, usize) -> Option<&'slice [u8]>;
+
+#[derive(Copy, Clone)]
+enum BorrowSource<'slice, R> {
+    None,
+    Slice(BorrowFn<'slice, R>),
+}
+
+impl<'slice, R> BorrowSource<'slice, R> {
+    #[inline]
+    fn try_borrow(&self, decoder: &mut Decoder<R>, len: usize) -> Option<&'slice [u8]> {
+        match self {
+            BorrowSource::None => None,
+            BorrowSource::Slice(func) => func(decoder, len),
+        }
+    }
+
+    #[inline]
+    fn can_borrow(&self) -> bool {
+        matches!(self, BorrowSource::Slice(_))
+    }
+
+    #[inline]
+    fn none() -> Self {
+        BorrowSource::None
+    }
+
+    #[inline]
+    fn from_slice(func: BorrowFn<'slice, R>) -> Self {
+        BorrowSource::Slice(func)
+    }
+}
+
+fn borrow_from_slice<'slice>(
+    decoder: &mut Decoder<&mut SliceReader<'slice>>,
+    len: usize,
+) -> Option<&'slice [u8]> {
+    decoder.try_borrow_slice(len)
 }
 
 fn noop(_: u8) {}
 
-impl<'a, R: Read> Deserializer<'a, R>
+impl<'slice, 'b, R: Read> Deserializer<'slice, 'b, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -73,6 +118,128 @@ where
         let result = func(self);
         self.recurse += 1;
         result
+    }
+
+    #[inline]
+    fn try_borrow_bytes(&mut self, len: usize) -> Result<Option<&'slice [u8]>, Error<R::Error>> {
+        if let Some(slice) = self.borrow.try_borrow(&mut self.decoder, len) {
+            return Ok(Some(slice));
+        }
+        Ok(None)
+    }
+
+    #[inline]
+    fn read_bytes(&mut self, len: usize) -> Result<Option<ByteSource<'slice>>, Error<R::Error>> {
+        if let Some(slice) = self.try_borrow_bytes(len)? {
+            return Ok(Some(ByteSource::Borrowed(slice)));
+        }
+
+        if len <= self.scratch.len() {
+            self.decoder.read_exact(&mut self.scratch[..len])?;
+            return Ok(Some(ByteSource::Scratch(len)));
+        }
+
+        Ok(None)
+    }
+
+    #[inline]
+    fn discard_bytes(&mut self, len: Option<usize>) -> Result<(), Error<R::Error>> {
+        if let Some(len) = len {
+            if self.try_borrow_bytes(len)?.is_some() {
+                return Ok(());
+            }
+        }
+
+        let mut segments = self.decoder.bytes(len);
+        while let Some(mut segment) = segments.pull()? {
+            while segment.pull(self.scratch)?.is_some() {}
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn discard_text(&mut self, len: Option<usize>) -> Result<(), Error<R::Error>> {
+        if let Some(len) = len {
+            let offset = self.decoder.offset();
+
+            if let Some(slice) = self.try_borrow_bytes(len)? {
+                match core::str::from_utf8(slice) {
+                    Ok(_) => return Ok(()),
+                    Err(_) => return Err(Error::Syntax(offset)),
+                }
+            }
+        }
+
+        let mut segments = self.decoder.text(len);
+        while let Some(mut segment) = segments.pull()? {
+            while segment.pull(self.scratch)?.is_some() {}
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn skip_value(&mut self) -> Result<(), Error<R::Error>> {
+        let header = self.decoder.pull()?;
+        self.skip_value_from_header(header)
+    }
+
+    #[inline]
+    fn skip_value_from_header(&mut self, header: Header) -> Result<(), Error<R::Error>> {
+        self.recurse(|me| me.skip_value_inner(header))
+    }
+
+    fn skip_value_inner(&mut self, header: Header) -> Result<(), Error<R::Error>> {
+        match header {
+            Header::Positive(..)
+            | Header::Negative(..)
+            | Header::Float(..)
+            | Header::Simple(..) => Ok(()),
+
+            Header::Bytes(len) => self.discard_bytes(len),
+            Header::Text(len) => self.discard_text(len),
+
+            Header::Array(len) => {
+                match len {
+                    Some(len) => {
+                        for _ in 0..len {
+                            self.skip_value()?;
+                        }
+                    }
+                    None => loop {
+                        match self.decoder.pull()? {
+                            Header::Break => break,
+                            header => self.skip_value_from_header(header)?,
+                        }
+                    },
+                }
+                Ok(())
+            }
+
+            Header::Map(len) => {
+                match len {
+                    Some(len) => {
+                        for _ in 0..len {
+                            self.skip_value()?;
+                            self.skip_value()?;
+                        }
+                    }
+                    None => loop {
+                        match self.decoder.pull()? {
+                            Header::Break => break,
+                            header => {
+                                self.skip_value_from_header(header)?;
+                                self.skip_value()?;
+                            }
+                        }
+                    },
+                }
+                Ok(())
+            }
+
+            Header::Tag(..) => self.skip_value(),
+
+            Header::Break => Err(header.expected("non-break")),
+        }
     }
 
     #[inline]
@@ -147,8 +314,9 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::Deserializer<'de> for &'a mut Deserializer<'b, R>
+impl<'de, 'a, 'slice, 'b, R: Read> de::Deserializer<'de> for &'a mut Deserializer<'slice, 'b, R>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -166,12 +334,16 @@ where
             },
 
             Header::Bytes(len) => match len {
-                Some(len) if len <= self.scratch.len() => self.deserialize_bytes(visitor),
+                Some(len) if self.borrow.can_borrow() || len <= self.scratch.len() => {
+                    self.deserialize_bytes(visitor)
+                }
                 _ => self.deserialize_byte_buf(visitor),
             },
 
             Header::Text(len) => match len {
-                Some(len) if len <= self.scratch.len() => self.deserialize_str(visitor),
+                Some(len) if self.borrow.can_borrow() || len <= self.scratch.len() => {
+                    self.deserialize_str(visitor)
+                }
                 _ => self.deserialize_string(visitor),
             },
 
@@ -350,14 +522,19 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Text(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-
-                    match core::str::from_utf8(&self.scratch[..len]) {
-                        Ok(s) => visitor.visit_str(s),
+                Header::Text(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => match core::str::from_utf8(slice) {
+                        Ok(s) => visitor.visit_borrowed_str(s),
                         Err(..) => Err(Error::Syntax(offset)),
+                    },
+                    Some(ByteSource::Scratch(len)) => {
+                        match core::str::from_utf8(&self.scratch[..len]) {
+                            Ok(s) => visitor.visit_str(s),
+                            Err(..) => Err(Error::Syntax(offset)),
+                        }
                     }
-                }
+                    None => Err(Header::Text(Some(len)).expected("str")),
+                },
 
                 header => Err(header.expected("str")),
             };
@@ -392,10 +569,11 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Bytes(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-                    visitor.visit_bytes(&self.scratch[..len])
-                }
+                Header::Bytes(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => visitor.visit_borrowed_bytes(slice),
+                    Some(ByteSource::Scratch(len)) => visitor.visit_bytes(&self.scratch[..len]),
+                    None => Err(Header::Bytes(Some(len)).expected("bytes")),
+                },
 
                 Header::Array(len) => self.recurse(|me| {
                     let access = Access(me, len);
@@ -517,18 +695,24 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Text(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-
-                    match core::str::from_utf8(&self.scratch[..len]) {
-                        Ok(s) => visitor.visit_str(s),
+                Header::Text(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => match core::str::from_utf8(slice) {
+                        Ok(s) => visitor.visit_borrowed_str(s),
                         Err(..) => Err(Error::Syntax(offset)),
+                    },
+                    Some(ByteSource::Scratch(len)) => {
+                        match core::str::from_utf8(&self.scratch[..len]) {
+                            Ok(s) => visitor.visit_str(s),
+                            Err(..) => Err(Error::Syntax(offset)),
+                        }
                     }
-                }
-                Header::Bytes(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-                    visitor.visit_bytes(&self.scratch[..len])
-                }
+                    None => Err(Header::Text(Some(len)).expected("str or bytes")),
+                },
+                Header::Bytes(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => visitor.visit_borrowed_bytes(slice),
+                    Some(ByteSource::Scratch(len)) => visitor.visit_bytes(&self.scratch[..len]),
+                    None => Err(Header::Bytes(Some(len)).expected("str or bytes")),
+                },
 
                 header => Err(header.expected("str or bytes")),
             };
@@ -539,7 +723,8 @@ where
         self,
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        self.deserialize_any(visitor)
+        self.skip_value()?;
+        visitor.visit_unit()
     }
 
     #[inline]
@@ -627,10 +812,11 @@ where
     }
 }
 
-struct Access<'a, 'b, R>(&'a mut Deserializer<'b, R>, Option<usize>);
+struct Access<'slice, 'a, 'b, R>(&'a mut Deserializer<'slice, 'b, R>, Option<usize>);
 
-impl<'de, 'a, 'b, R: Read> de::SeqAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read> de::SeqAccess<'de> for Access<'slice, 'a, 'b, R>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -658,8 +844,9 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::MapAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read> de::MapAccess<'de> for Access<'slice, 'a, 'b, R>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -695,8 +882,9 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::EnumAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read> de::EnumAccess<'de> for Access<'slice, 'a, 'b, R>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -712,8 +900,9 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::VariantAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read> de::VariantAccess<'de> for Access<'slice, 'a, 'b, R>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -780,6 +969,93 @@ where
     }
 }
 
+/// Deserializes as CBOR from a byte slice using a 4KB buffer on the stack.
+///
+/// Unlike [`from_reader`](from_reader), this function accepts types that implement
+/// `Deserialize<'de>` rather than `DeserializeOwned`, allowing deserialized data
+/// to have lifetime parameters tied to the input slice.
+///
+/// # Example
+/// ```
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize, Debug, PartialEq)]
+/// struct Data {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // CBOR encoding of {"name": "Alice", "age": 30}
+/// let input = b"\xa2\x64name\x65Alice\x63age\x18\x1e";
+/// let data: Data = ciborium::de::from_slice(input)?;
+/// assert_eq!(data, Data { name: "Alice".to_string(), age: 30 });
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn from_slice<'de, T>(slice: &'de [u8]) -> Result<T, Error<EndOfSliceError>>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut scratch = [0; 4096];
+    from_slice_with_buffer(slice, &mut scratch)
+}
+
+/// Deserializes as CBOR from a byte slice, using a caller-specific buffer as a
+/// temporary scratch space.
+///
+/// This is the slice equivalent of [`from_reader_with_buffer`](from_reader_with_buffer),
+/// supporting zero-copy deserialization for types that implement `Deserialize<'de>`.
+#[inline]
+pub fn from_slice_with_buffer<'de, T>(
+    slice: &'de [u8],
+    scratch_buffer: &mut [u8],
+) -> Result<T, Error<EndOfSliceError>>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut reader = SliceReader::new(slice);
+    let borrow = BorrowSource::from_slice(borrow_from_slice);
+    let mut deserializer = Deserializer {
+        decoder: (&mut reader).into(),
+        scratch: scratch_buffer,
+        recurse: 256,
+        borrow,
+    };
+
+    T::deserialize(&mut deserializer)
+}
+
+/// Deserializes as CBOR from a byte slice with a specified maximum recursion limit.
+///
+/// This is the slice equivalent of [`from_reader_with_recursion_limit`](from_reader_with_recursion_limit),
+/// supporting zero-copy deserialization. Inputs nested beyond the specified limit
+/// will result in [`Error::RecursionLimitExceeded`].
+///
+/// Set a high recursion limit at your own risk (of stack exhaustion)!
+#[inline]
+pub fn from_slice_with_recursion_limit<'de, T>(
+    slice: &'de [u8],
+    recurse_limit: usize,
+) -> Result<T, Error<EndOfSliceError>>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut scratch = [0; 4096];
+
+    let mut reader = SliceReader::new(slice);
+    let borrow = BorrowSource::from_slice(borrow_from_slice);
+    let mut deserializer = Deserializer {
+        decoder: (&mut reader).into(),
+        scratch: &mut scratch,
+        recurse: recurse_limit,
+        borrow,
+    };
+
+    T::deserialize(&mut deserializer)
+}
+
 /// Deserializes as CBOR from a type with [`impl
 /// ciborium_io::Read`](ciborium_io::Read) using a 4KB buffer on the stack.
 ///
@@ -810,6 +1086,7 @@ where
         decoder: reader.into(),
         scratch: scratch_buffer,
         recurse: 256,
+        borrow: BorrowSource::none(),
     };
 
     T::deserialize(&mut reader)
@@ -834,6 +1111,7 @@ where
         decoder: reader.into(),
         scratch: &mut scratch,
         recurse: recurse_limit,
+        borrow: BorrowSource::none(),
     };
 
     T::deserialize(&mut reader)
@@ -844,7 +1122,7 @@ where
 pub fn deserializer_from_reader_with_buffer<R: Read>(
     reader: R,
     scratch_buffer: &mut [u8],
-) -> Deserializer<'_, R>
+) -> Deserializer<'static, '_, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -852,6 +1130,7 @@ where
         decoder: reader.into(),
         scratch: scratch_buffer,
         recurse: 256,
+        borrow: BorrowSource::none(),
     }
 }
 
@@ -865,7 +1144,7 @@ pub fn deserializer_from_reader_with_buffer_and_recursion_limit<R: Read>(
     reader: R,
     scratch_buffer: &mut [u8],
     recurse_limit: usize,
-) -> Deserializer<'_, R>
+) -> Deserializer<'static, '_, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -873,5 +1152,6 @@ where
         decoder: reader.into(),
         scratch: scratch_buffer,
         recurse: recurse_limit,
+        borrow: BorrowSource::none(),
     }
 }

--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -8,11 +8,10 @@ pub use error::Error;
 
 use alloc::{string::String, vec::Vec};
 
-use ciborium_io::Read;
+use crate::tag::TagAccess;
+use ciborium_io::{EndOfSliceError, Read, SliceReader};
 use ciborium_ll::*;
 use serde::de::{self, value::BytesDeserializer, Deserializer as _};
-
-use crate::tag::TagAccess;
 
 trait Expected<E: de::Error> {
     fn expected(self, kind: &'static str) -> E;
@@ -48,15 +47,56 @@ impl<E: de::Error> Expected<E> for Header {
 }
 
 /// Deserializer
-pub struct Deserializer<'b, R> {
+pub struct Deserializer<'slice, 'b, R, B = NoBorrow> {
     decoder: Decoder<R>,
     scratch: &'b mut [u8],
     recurse: usize,
+    source: core::marker::PhantomData<(&'slice [u8], B)>,
+}
+
+enum ByteSource<'slice> {
+    Borrowed(&'slice [u8]),
+    Scratch(usize),
+}
+
+/// The non-borrowing strategy used by reader-backed deserializers.
+#[doc(hidden)]
+#[derive(Copy, Clone)]
+pub struct NoBorrow;
+
+/// The borrowing strategy used by slice-backed deserializers.
+#[doc(hidden)]
+#[derive(Copy, Clone)]
+pub struct BorrowSlice;
+
+#[doc(hidden)]
+pub trait BorrowSource<'slice, R> {
+    const CAN_BORROW: bool;
+
+    fn try_borrow(decoder: &mut Decoder<R>, len: usize) -> Option<&'slice [u8]>;
+}
+
+impl<'slice, R> BorrowSource<'slice, R> for NoBorrow {
+    const CAN_BORROW: bool = false;
+
+    #[inline]
+    fn try_borrow(_: &mut Decoder<R>, _: usize) -> Option<&'slice [u8]> {
+        None
+    }
+}
+
+impl<'slice> BorrowSource<'slice, SliceReader<'slice>> for BorrowSlice {
+    const CAN_BORROW: bool = true;
+
+    #[inline]
+    fn try_borrow(decoder: &mut Decoder<SliceReader<'slice>>, len: usize) -> Option<&'slice [u8]> {
+        decoder.try_borrow_slice(len)
+    }
 }
 
 fn noop(_: u8) {}
 
-impl<'a, R: Read> Deserializer<'a, R>
+impl<'slice, 'b, R: Read, B: BorrowSource<'slice, R>> Deserializer<'slice, 'b, R, B>
 where
     R::Error: core::fmt::Debug,
 {
@@ -73,6 +113,125 @@ where
         let result = func(self);
         self.recurse += 1;
         result
+    }
+
+    #[inline]
+    fn try_borrow_bytes(&mut self, len: usize) -> Option<&'slice [u8]> {
+        B::try_borrow(&mut self.decoder, len)
+    }
+
+    #[inline]
+    fn read_bytes(&mut self, len: usize) -> Result<Option<ByteSource<'slice>>, Error<R::Error>> {
+        if let Some(slice) = self.try_borrow_bytes(len) {
+            return Ok(Some(ByteSource::Borrowed(slice)));
+        }
+
+        if len <= self.scratch.len() {
+            self.decoder.read_exact(&mut self.scratch[..len])?;
+            return Ok(Some(ByteSource::Scratch(len)));
+        }
+
+        Ok(None)
+    }
+
+    #[inline]
+    fn discard_bytes(&mut self, len: Option<usize>) -> Result<(), Error<R::Error>> {
+        if let Some(len) = len {
+            if self.try_borrow_bytes(len).is_some() {
+                return Ok(());
+            }
+        }
+
+        let mut segments = self.decoder.bytes(len);
+        while let Some(mut segment) = segments.pull()? {
+            while segment.pull(self.scratch)?.is_some() {}
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn discard_text(&mut self, len: Option<usize>) -> Result<(), Error<R::Error>> {
+        if let Some(len) = len {
+            let offset = self.decoder.offset();
+
+            if let Some(slice) = self.try_borrow_bytes(len) {
+                match core::str::from_utf8(slice) {
+                    Ok(_) => return Ok(()),
+                    Err(_) => return Err(Error::Syntax(offset)),
+                }
+            }
+        }
+
+        let mut segments = self.decoder.text(len);
+        while let Some(mut segment) = segments.pull()? {
+            while segment.pull(self.scratch)?.is_some() {}
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn skip_value(&mut self) -> Result<(), Error<R::Error>> {
+        let header = self.decoder.pull()?;
+        self.skip_value_from_header(header)
+    }
+
+    #[inline]
+    fn skip_value_from_header(&mut self, header: Header) -> Result<(), Error<R::Error>> {
+        self.recurse(|me| me.skip_value_inner(header))
+    }
+
+    fn skip_value_inner(&mut self, header: Header) -> Result<(), Error<R::Error>> {
+        match header {
+            Header::Positive(..)
+            | Header::Negative(..)
+            | Header::Float(..)
+            | Header::Simple(..) => Ok(()),
+
+            Header::Bytes(len) => self.discard_bytes(len),
+            Header::Text(len) => self.discard_text(len),
+
+            Header::Array(len) => {
+                match len {
+                    Some(len) => {
+                        for _ in 0..len {
+                            self.skip_value()?;
+                        }
+                    }
+                    None => loop {
+                        match self.decoder.pull()? {
+                            Header::Break => break,
+                            header => self.skip_value_from_header(header)?,
+                        }
+                    },
+                }
+                Ok(())
+            }
+
+            Header::Map(len) => {
+                match len {
+                    Some(len) => {
+                        for _ in 0..len {
+                            self.skip_value()?;
+                            self.skip_value()?;
+                        }
+                    }
+                    None => loop {
+                        match self.decoder.pull()? {
+                            Header::Break => break,
+                            header => {
+                                self.skip_value_from_header(header)?;
+                                self.skip_value()?;
+                            }
+                        }
+                    },
+                }
+                Ok(())
+            }
+
+            Header::Tag(..) => self.skip_value(),
+
+            Header::Break => Err(header.expected("non-break")),
+        }
     }
 
     #[inline]
@@ -147,8 +306,10 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::Deserializer<'de> for &'a mut Deserializer<'b, R>
+impl<'de, 'a, 'slice, 'b, R: Read, B: BorrowSource<'slice, R>> de::Deserializer<'de>
+    for &'a mut Deserializer<'slice, 'b, R, B>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -166,12 +327,16 @@ where
             },
 
             Header::Bytes(len) => match len {
-                Some(len) if len <= self.scratch.len() => self.deserialize_bytes(visitor),
+                Some(len) if B::CAN_BORROW || len <= self.scratch.len() => {
+                    self.deserialize_bytes(visitor)
+                }
                 _ => self.deserialize_byte_buf(visitor),
             },
 
             Header::Text(len) => match len {
-                Some(len) if len <= self.scratch.len() => self.deserialize_str(visitor),
+                Some(len) if B::CAN_BORROW || len <= self.scratch.len() => {
+                    self.deserialize_str(visitor)
+                }
                 _ => self.deserialize_string(visitor),
             },
 
@@ -350,14 +515,19 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Text(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-
-                    match core::str::from_utf8(&self.scratch[..len]) {
-                        Ok(s) => visitor.visit_str(s),
+                Header::Text(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => match core::str::from_utf8(slice) {
+                        Ok(s) => visitor.visit_borrowed_str(s),
                         Err(..) => Err(Error::Syntax(offset)),
+                    },
+                    Some(ByteSource::Scratch(len)) => {
+                        match core::str::from_utf8(&self.scratch[..len]) {
+                            Ok(s) => visitor.visit_str(s),
+                            Err(..) => Err(Error::Syntax(offset)),
+                        }
                     }
-                }
+                    None => Err(Header::Text(Some(len)).expected("str")),
+                },
 
                 header => Err(header.expected("str")),
             };
@@ -366,10 +536,27 @@ where
 
     fn deserialize_string<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         loop {
+            let offset = self.decoder.offset();
+
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
                 Header::Text(len) => {
+                    if let Some(slice) = len.and_then(|len| self.try_borrow_bytes(len)) {
+                        let string = core::str::from_utf8(slice)
+                            .map_err(|_| Error::Syntax(offset))?
+                            .into();
+                        return visitor.visit_string(string);
+                    }
+
+                    if let Some(len) = len.filter(|len| *len <= self.scratch.len()) {
+                        self.decoder.read_exact(&mut self.scratch[..len])?;
+                        let string = core::str::from_utf8(&self.scratch[..len])
+                            .map_err(|_| Error::Syntax(offset))?
+                            .into();
+                        return visitor.visit_string(string);
+                    }
+
                     let mut buffer = String::new();
 
                     let mut segments = self.decoder.text(len);
@@ -392,10 +579,11 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Bytes(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-                    visitor.visit_bytes(&self.scratch[..len])
-                }
+                Header::Bytes(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => visitor.visit_borrowed_bytes(slice),
+                    Some(ByteSource::Scratch(len)) => visitor.visit_bytes(&self.scratch[..len]),
+                    None => Err(Header::Bytes(Some(len)).expected("bytes")),
+                },
 
                 Header::Array(len) => self.recurse(|me| {
                     let access = Access(me, len);
@@ -416,6 +604,15 @@ where
                 Header::Tag(..) => continue,
 
                 Header::Bytes(len) => {
+                    if let Some(slice) = len.and_then(|len| self.try_borrow_bytes(len)) {
+                        return visitor.visit_byte_buf(slice.into());
+                    }
+
+                    if let Some(len) = len.filter(|len| *len <= self.scratch.len()) {
+                        self.decoder.read_exact(&mut self.scratch[..len])?;
+                        return visitor.visit_byte_buf(self.scratch[..len].into());
+                    }
+
                     let mut buffer = Vec::new();
 
                     let mut segments = self.decoder.bytes(len);
@@ -517,18 +714,24 @@ where
             return match self.decoder.pull()? {
                 Header::Tag(..) => continue,
 
-                Header::Text(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-
-                    match core::str::from_utf8(&self.scratch[..len]) {
-                        Ok(s) => visitor.visit_str(s),
+                Header::Text(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => match core::str::from_utf8(slice) {
+                        Ok(s) => visitor.visit_borrowed_str(s),
                         Err(..) => Err(Error::Syntax(offset)),
+                    },
+                    Some(ByteSource::Scratch(len)) => {
+                        match core::str::from_utf8(&self.scratch[..len]) {
+                            Ok(s) => visitor.visit_str(s),
+                            Err(..) => Err(Error::Syntax(offset)),
+                        }
                     }
-                }
-                Header::Bytes(Some(len)) if len <= self.scratch.len() => {
-                    self.decoder.read_exact(&mut self.scratch[..len])?;
-                    visitor.visit_bytes(&self.scratch[..len])
-                }
+                    None => Err(Header::Text(Some(len)).expected("str or bytes")),
+                },
+                Header::Bytes(Some(len)) => match self.read_bytes(len)? {
+                    Some(ByteSource::Borrowed(slice)) => visitor.visit_borrowed_bytes(slice),
+                    Some(ByteSource::Scratch(len)) => visitor.visit_bytes(&self.scratch[..len]),
+                    None => Err(Header::Bytes(Some(len)).expected("str or bytes")),
+                },
 
                 header => Err(header.expected("str or bytes")),
             };
@@ -539,7 +742,8 @@ where
         self,
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
-        self.deserialize_any(visitor)
+        self.skip_value()?;
+        visitor.visit_unit()
     }
 
     #[inline]
@@ -627,10 +831,12 @@ where
     }
 }
 
-struct Access<'a, 'b, R>(&'a mut Deserializer<'b, R>, Option<usize>);
+struct Access<'slice, 'a, 'b, R, B>(&'a mut Deserializer<'slice, 'b, R, B>, Option<usize>);
 
-impl<'de, 'a, 'b, R: Read> de::SeqAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read, B: BorrowSource<'slice, R>> de::SeqAccess<'de>
+    for Access<'slice, 'a, 'b, R, B>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -658,8 +864,10 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::MapAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read, B: BorrowSource<'slice, R>> de::MapAccess<'de>
+    for Access<'slice, 'a, 'b, R, B>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -695,8 +903,10 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::EnumAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read, B: BorrowSource<'slice, R>> de::EnumAccess<'de>
+    for Access<'slice, 'a, 'b, R, B>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -712,8 +922,10 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::VariantAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'slice, 'a, 'b, R: Read, B: BorrowSource<'slice, R>> de::VariantAccess<'de>
+    for Access<'slice, 'a, 'b, R, B>
 where
+    'slice: 'de,
     R::Error: core::fmt::Debug,
 {
     type Error = Error<R::Error>;
@@ -780,6 +992,89 @@ where
     }
 }
 
+/// Deserializes as CBOR from a byte slice using a 4KB buffer on the stack.
+///
+/// Unlike [`from_reader`](from_reader), this function accepts types that implement
+/// `Deserialize<'de>` rather than `DeserializeOwned`, allowing deserialized data
+/// to have lifetime parameters tied to the input slice.
+///
+/// # Example
+/// ```
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize, Debug, PartialEq)]
+/// struct Data {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // CBOR encoding of {"name": "Alice", "age": 30}
+/// let input = b"\xa2\x64name\x65Alice\x63age\x18\x1e";
+/// let data: Data = ciborium::de::from_slice(input)?;
+/// assert_eq!(data, Data { name: "Alice".to_string(), age: 30 });
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn from_slice<'de, T>(slice: &'de [u8]) -> Result<T, Error<EndOfSliceError>>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut scratch = [0; 4096];
+    from_slice_with_buffer(slice, &mut scratch)
+}
+
+/// Deserializes as CBOR from a byte slice, using a caller-specific buffer as a
+/// temporary scratch space.
+///
+/// This is the slice equivalent of [`from_reader_with_buffer`](from_reader_with_buffer),
+/// supporting zero-copy deserialization for types that implement `Deserialize<'de>`.
+#[inline]
+pub fn from_slice_with_buffer<'de, T>(
+    slice: &'de [u8],
+    scratch_buffer: &mut [u8],
+) -> Result<T, Error<EndOfSliceError>>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut deserializer = Deserializer {
+        decoder: SliceReader::new(slice).into(),
+        scratch: scratch_buffer,
+        recurse: 256,
+        source: core::marker::PhantomData::<(&[u8], BorrowSlice)>,
+    };
+
+    T::deserialize(&mut deserializer)
+}
+
+/// Deserializes as CBOR from a byte slice with a specified maximum recursion limit.
+///
+/// This is the slice equivalent of [`from_reader_with_recursion_limit`](from_reader_with_recursion_limit),
+/// supporting zero-copy deserialization. Inputs nested beyond the specified limit
+/// will result in [`Error::RecursionLimitExceeded`].
+///
+/// Set a high recursion limit at your own risk (of stack exhaustion)!
+#[inline]
+pub fn from_slice_with_recursion_limit<'de, T>(
+    slice: &'de [u8],
+    recurse_limit: usize,
+) -> Result<T, Error<EndOfSliceError>>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut scratch = [0; 4096];
+
+    let mut deserializer = Deserializer {
+        decoder: SliceReader::new(slice).into(),
+        scratch: &mut scratch,
+        recurse: recurse_limit,
+        source: core::marker::PhantomData::<(&[u8], BorrowSlice)>,
+    };
+
+    T::deserialize(&mut deserializer)
+}
+
 /// Deserializes as CBOR from a type with [`impl
 /// ciborium_io::Read`](ciborium_io::Read) using a 4KB buffer on the stack.
 ///
@@ -810,6 +1105,7 @@ where
         decoder: reader.into(),
         scratch: scratch_buffer,
         recurse: 256,
+        source: core::marker::PhantomData::<(&[u8], NoBorrow)>,
     };
 
     T::deserialize(&mut reader)
@@ -834,6 +1130,7 @@ where
         decoder: reader.into(),
         scratch: &mut scratch,
         recurse: recurse_limit,
+        source: core::marker::PhantomData::<(&[u8], NoBorrow)>,
     };
 
     T::deserialize(&mut reader)
@@ -844,7 +1141,7 @@ where
 pub fn deserializer_from_reader_with_buffer<R: Read>(
     reader: R,
     scratch_buffer: &mut [u8],
-) -> Deserializer<'_, R>
+) -> Deserializer<'static, '_, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -852,6 +1149,7 @@ where
         decoder: reader.into(),
         scratch: scratch_buffer,
         recurse: 256,
+        source: core::marker::PhantomData::<(&[u8], NoBorrow)>,
     }
 }
 
@@ -865,7 +1163,7 @@ pub fn deserializer_from_reader_with_buffer_and_recursion_limit<R: Read>(
     reader: R,
     scratch_buffer: &mut [u8],
     recurse_limit: usize,
-) -> Deserializer<'_, R>
+) -> Deserializer<'static, '_, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -873,5 +1171,6 @@ where
         decoder: reader.into(),
         scratch: scratch_buffer,
         recurse: recurse_limit,
+        source: core::marker::PhantomData::<(&[u8], NoBorrow)>,
     }
 }

--- a/ciborium/src/lib.rs
+++ b/ciborium/src/lib.rs
@@ -102,6 +102,10 @@ pub mod value;
 pub use crate::de::from_reader;
 #[doc(inline)]
 pub use crate::de::from_reader_with_buffer;
+#[doc(inline)]
+pub use crate::de::from_slice;
+#[doc(inline)]
+pub use crate::de::from_slice_with_buffer;
 
 #[doc(inline)]
 pub use crate::ser::into_writer;

--- a/ciborium/tests/codec.rs
+++ b/ciborium/tests/codec.rs
@@ -301,7 +301,7 @@ fn codec<'de, T: Serialize + Clone, V: Debug + PartialEq + DeserializeOwned, F: 
         assert_eq!(bytes, encoded);
 
         let encoded = Value::serialized(&input).unwrap();
-        eprintln!("{:x?} == {:x?}", &value, &encoded);
+        eprintln!("{value:x?} == {encoded:x?}");
         assert!(veq(&value, &encoded));
     }
 
@@ -311,12 +311,12 @@ fn codec<'de, T: Serialize + Clone, V: Debug + PartialEq + DeserializeOwned, F: 
     assert_eq!(answer, decoded);
 
     let decoded: Value = from_reader(&bytes[..]).unwrap();
-    eprintln!("{:x?} == {:x?}", &value, &decoded);
+    eprintln!("{value:x?} == {decoded:x?}");
     assert!(veq(&value, &decoded));
 
     let mut scratch = vec![0; 65536];
     let decoded: Value = from_reader_with_buffer(&bytes[..], &mut scratch).unwrap();
-    eprintln!("{:x?} == {:x?}", &value, &decoded);
+    eprintln!("{value:x?} == {decoded:x?}");
     assert!(veq(&value, &decoded));
 
     let decoded: V = value.deserialized().unwrap();

--- a/ciborium/tests/from_slice.rs
+++ b/ciborium/tests/from_slice.rs
@@ -1,0 +1,96 @@
+// Tests for from_slice with Deserialize<'de> support
+
+use serde::Deserialize;
+
+#[test]
+fn test_from_slice_with_owned_data() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Data {
+        title: String,
+        count: u64,
+    }
+
+    // CBOR: {"title": "Test Data", "count": 42}
+    let cbor_data = b"\xa2\x65title\x69Test Data\x65count\x18\x2a";
+    let data: Data = ciborium::from_slice(cbor_data).unwrap();
+
+    assert_eq!(data.title, "Test Data");
+    assert_eq!(data.count, 42);
+}
+
+#[test]
+fn test_from_slice_with_deserialize_lifetime() {
+    #[derive(Deserialize, Debug)]
+    struct Person<'a> {
+        #[serde(borrow)]
+        name: &'a str,
+        age: u32,
+    }
+
+    // CBOR: {"name": "Alice", "age": 30}
+    let cbor_person = b"\xa2\x64name\x65Alice\x63age\x18\x1e";
+
+    // This demonstrates that from_slice accepts Deserialize<'de> types
+    let person: Person = ciborium::from_slice(cbor_person).unwrap();
+    assert_eq!(person.name, "Alice");
+    assert_eq!(person.age, 30);
+}
+
+#[test]
+fn test_from_slice_array() {
+    // CBOR: [1, 2, 3, 4, 5]
+    let cbor_array = b"\x85\x01\x02\x03\x04\x05";
+    let array: Vec<u32> = ciborium::from_slice(cbor_array).unwrap();
+    assert_eq!(array, vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn test_from_slice_with_buffer() {
+    use std::collections::HashMap;
+
+    // CBOR: {"a": 1, "b": 2, "c": 3}
+    let cbor_map = b"\xa3\x61a\x01\x61b\x02\x61c\x03";
+    let mut buffer = [0u8; 8192];
+
+    let map: HashMap<String, u32> =
+        ciborium::de::from_slice_with_buffer(cbor_map, &mut buffer).unwrap();
+
+    assert_eq!(map.get("a"), Some(&1));
+    assert_eq!(map.get("b"), Some(&2));
+    assert_eq!(map.get("c"), Some(&3));
+}
+
+#[test]
+fn test_from_slice_nested_structures() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Outer {
+        inner: Inner,
+        list: Vec<u32>,
+    }
+
+    // CBOR: {"inner": {"value": 42}, "list": [1, 2, 3]}
+    let cbor = b"\xa2\x65inner\xa1\x65value\x18\x2a\x64list\x83\x01\x02\x03";
+    let outer: Outer = ciborium::from_slice(cbor).unwrap();
+
+    assert_eq!(outer.inner.value, 42);
+    assert_eq!(outer.list, vec![1, 2, 3]);
+}
+
+#[test]
+fn test_from_slice_with_recursion_limit() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct SimpleStruct {
+        value: u32,
+    }
+
+    // CBOR: {"value": 100}
+    let cbor = b"\xa1\x65value\x18\x64";
+    let data: SimpleStruct = ciborium::de::from_slice_with_recursion_limit(cbor, 256).unwrap();
+
+    assert_eq!(data.value, 100);
+}

--- a/ciborium/tests/from_slice.rs
+++ b/ciborium/tests/from_slice.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for from_slice with Deserialize<'de> support
+
+use serde::Deserialize;
+use serde_bytes::ByteBuf;
+
+#[test]
+fn test_from_slice_with_owned_data() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Data {
+        title: String,
+        count: u64,
+    }
+
+    // CBOR: {"title": "Test Data", "count": 42}
+    let cbor_data = b"\xa2\x65title\x69Test Data\x65count\x18\x2a";
+    let data: Data = ciborium::from_slice(cbor_data).unwrap();
+
+    assert_eq!(data.title, "Test Data");
+    assert_eq!(data.count, 42);
+}
+
+#[test]
+fn test_from_slice_with_deserialize_lifetime() {
+    #[derive(Deserialize, Debug)]
+    struct Person<'a> {
+        #[serde(borrow)]
+        name: &'a str,
+        age: u32,
+    }
+
+    // CBOR: {"name": "Alice", "age": 30}
+    let cbor_person = b"\xa2\x64name\x65Alice\x63age\x18\x1e";
+
+    // This demonstrates that from_slice accepts Deserialize<'de> types
+    let person: Person = ciborium::from_slice(cbor_person).unwrap();
+    assert_eq!(person.name, "Alice");
+    assert_eq!(person.age, 30);
+}
+
+#[test]
+fn test_from_slice_array() {
+    // CBOR: [1, 2, 3, 4, 5]
+    let cbor_array = b"\x85\x01\x02\x03\x04\x05";
+    let array: Vec<u32> = ciborium::from_slice(cbor_array).unwrap();
+    assert_eq!(array, vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn test_from_slice_with_buffer() {
+    use std::collections::HashMap;
+
+    // CBOR: {"a": 1, "b": 2, "c": 3}
+    let cbor_map = b"\xa3\x61a\x01\x61b\x02\x61c\x03";
+    let mut buffer = [0u8; 8192];
+
+    let map: HashMap<String, u32> =
+        ciborium::de::from_slice_with_buffer(cbor_map, &mut buffer).unwrap();
+
+    assert_eq!(map.get("a"), Some(&1));
+    assert_eq!(map.get("b"), Some(&2));
+    assert_eq!(map.get("c"), Some(&3));
+}
+
+#[test]
+fn test_from_slice_nested_structures() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Outer {
+        inner: Inner,
+        list: Vec<u32>,
+    }
+
+    // CBOR: {"inner": {"value": 42}, "list": [1, 2, 3]}
+    let cbor = b"\xa2\x65inner\xa1\x65value\x18\x2a\x64list\x83\x01\x02\x03";
+    let outer: Outer = ciborium::from_slice(cbor).unwrap();
+
+    assert_eq!(outer.inner.value, 42);
+    assert_eq!(outer.list, vec![1, 2, 3]);
+}
+
+#[test]
+fn test_from_slice_with_recursion_limit() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct SimpleStruct {
+        value: u32,
+    }
+
+    // CBOR: {"value": 100}
+    let cbor = b"\xa1\x65value\x18\x64";
+    let data: SimpleStruct = ciborium::de::from_slice_with_recursion_limit(cbor, 256).unwrap();
+
+    assert_eq!(data.value, 100);
+}
+
+#[test]
+fn test_from_slice_with_owned_bytes_larger_than_scratch() {
+    let payload = vec![42; 8192];
+    let mut encoded = Vec::new();
+    ciborium::ser::into_writer(&ByteBuf::from(payload.clone()), &mut encoded).unwrap();
+
+    let decoded: ByteBuf = ciborium::from_slice(&encoded).unwrap();
+    assert_eq!(decoded.as_ref(), payload);
+}
+
+#[test]
+fn test_from_slice_with_indefinite_string_and_bytes() {
+    let text: String = ciborium::from_slice(b"\x7f\x62hi\x61!\xff").unwrap();
+    assert_eq!(text, "hi!");
+
+    let bytes: ByteBuf = ciborium::from_slice(b"\x5f\x42\x01\x02\x41\x03\xff").unwrap();
+    assert_eq!(bytes.as_ref(), [1, 2, 3]);
+}
+
+#[test]
+fn test_from_slice_reports_truncated_owned_values() {
+    let text = ciborium::from_slice::<String>(b"\x65abc").unwrap_err();
+    assert!(matches!(text, ciborium::de::Error::Io(_)));
+
+    let bytes = ciborium::from_slice::<ByteBuf>(b"\x45\x01\x02\x03").unwrap_err();
+    assert!(matches!(bytes, ciborium::de::Error::Io(_)));
+}
+
+#[test]
+fn test_from_slice_rejects_invalid_owned_utf8() {
+    let error = ciborium::from_slice::<String>(b"\x62\xff\xff").unwrap_err();
+    assert!(matches!(error, ciborium::de::Error::Syntax(0)));
+}


### PR DESCRIPTION
This PR aims to close #36 and #117 by providing a `from_slice` implementation that supports borrowed data / zerocopy deserialization of strings and bytes (similar to serde_json and serde_cbor). 

The implementation is a little awkward in places between the `Deserializer` and the `Decoder` needing to both interact with `SliceReader`, but I've tried to follow the existing code as much as possible.

Happy to make any amendments you see fit. Cheers, Liam.

Note I also have a performance improvements PR (20-40% faster decode, 15% faster encode) here, but it's stacked on top of this PR: https://github.com/hoxxep/ciborium/pull/1

## Benchmarks

Ran on an M1 Max, the benchmarks create a sample document and repeatedly serialize or deserialize depending on the benchmark. `from_slice_borrowed` uses some zerocopy/reference types.

```
into_writer             time:   [1.7981 µs 1.8073 µs 1.8203 µs]
from_reader             time:   [13.072 µs 13.151 µs 13.257 µs]
from_slice              time:   [12.421 µs 12.471 µs 12.554 µs]
from_slice_borrowed     time:   [10.778 µs 10.823 µs 10.877 µs]
```

A previous version of this PR caused a performance regression in `from_reader`, but I believe that performance gap has been fixed with this set of changes.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
