### PR TITLE
fix: enforce RFC 8949 well-formedness and fix decoding, canonical ordering bugs

### DIFF
--- a/ciborium-ll/src/dec.rs
+++ b/ciborium-ll/src/dec.rs
@@ -130,7 +130,7 @@ impl<R: Read> Decoder<R> {
     /// bytes were already read from the reader before the decoder was created,
     /// you must account for this.
     #[inline]
-    pub fn offset(&mut self) -> usize {
+    pub fn offset(&self) -> usize {
         self.offset
     }
 
@@ -141,10 +141,10 @@ impl<R: Read> Decoder<R> {
     /// be called immediately after first pulling a `Header::Bytes(len)` from
     /// the wire and `len` must be provided to this function from that value.
     ///
-    /// The `buf` parameter provides a buffer used when reading in the segmented
-    /// bytes. A large buffer will result in fewer calls to read incoming bytes
-    /// at the cost of memory usage. You should consider this trade off when
-    /// deciding the size of your buffer.
+    /// The buffer passed to `Segment::pull()` controls how many bytes are
+    /// read at a time. A large buffer will result in fewer calls to read
+    /// incoming bytes at the cost of memory usage. You should consider this
+    /// trade off when deciding the size of your buffer.
     #[inline]
     pub fn bytes<'a>(&'a mut self, len: Option<usize>) -> Segments<'a, R, crate::seg::Bytes> {
         self.push(Header::Bytes(len));
@@ -161,10 +161,11 @@ impl<R: Read> Decoder<R> {
     /// be called immediately after first pulling a `Header::Text(len)` from
     /// the wire and `len` must be provided to this function from that value.
     ///
-    /// The `buf` parameter provides a buffer used when reading in the segmented
-    /// text. A large buffer will result in fewer calls to read incoming bytes
-    /// at the cost of memory usage. You should consider this trade off when
-    /// deciding the size of your buffer.
+    /// The buffer passed to `Segment::pull()` controls how many bytes are
+    /// read at a time; it must hold at least 4 bytes to make progress on all
+    /// inputs. A large buffer will result in fewer calls to read incoming
+    /// bytes at the cost of memory usage. You should consider this trade off
+    /// when deciding the size of your buffer.
     #[inline]
     pub fn text<'a>(&'a mut self, len: Option<usize>) -> Segments<'a, R, crate::seg::Text> {
         self.push(Header::Text(len));

--- a/ciborium-ll/src/hdr.rs
+++ b/ciborium-ll/src/hdr.rs
@@ -29,6 +29,10 @@ pub enum Header {
     Float(f64),
 
     /// A "simple" value
+    ///
+    /// Note well that values 24 to 31 (inclusive) are reserved by RFC 8949
+    /// and have no valid encoding: pushing such a header produces a two-byte
+    /// sequence that is not well-formed and will be rejected when decoded.
     Simple(u8),
 
     /// A tag
@@ -111,7 +115,11 @@ impl TryFrom<Title> for Header {
 
             Title(Major::Other, Minor::More) => Self::Break,
             Title(Major::Other, Minor::This(x)) => Self::Simple(x),
-            Title(Major::Other, Minor::Next1(x)) => Self::Simple(x[0]),
+
+            // RFC 8949 §3.3: two-byte sequences that start with 0xf8 and
+            // continue with a byte less than 0x20 are not well-formed.
+            Title(Major::Other, Minor::Next1([x])) if x >= 32 => Self::Simple(x),
+            Title(Major::Other, Minor::Next1(..)) => return Err(InvalidError(())),
             Title(Major::Other, Minor::Next2(x)) => Self::Float(f16::from_be_bytes(x).into()),
             Title(Major::Other, Minor::Next4(x)) => Self::Float(f32::from_be_bytes(x).into()),
             Title(Major::Other, Minor::Next8(x)) => Self::Float(f64::from_be_bytes(x)),

--- a/ciborium-ll/src/lib.rs
+++ b/ciborium-ll/src/lib.rs
@@ -277,7 +277,7 @@ mod tests {
             (Header::Simple(simple::NULL), "f6", true),
             (Header::Simple(simple::UNDEFINED), "f7", true),
             (Header::Simple(16), "f0", true),
-            (Header::Simple(24), "f818", true),
+            (Header::Simple(32), "f820", true),
             (Header::Simple(255), "f8ff", true),
             (Header::Tag(0), "c0", true),
             (Header::Tag(1), "c1", true),
@@ -311,6 +311,26 @@ mod tests {
                 let len = writer.len();
                 assert_eq!(&bytes[..], &buffer[..1024 - len]);
             }
+        }
+    }
+
+    #[test]
+    fn simple_reserved() {
+        // RFC 8949 §3.3: 0xf8 followed by a byte less than 0x20 is not
+        // well-formed and must be rejected.
+        for x in 0u8..32 {
+            let bytes = [0xf8, x];
+            let mut decoder = Decoder::from(&bytes[..]);
+            assert!(
+                matches!(decoder.pull(), Err(Error::Syntax(0))),
+                "f8{x:02x} must be rejected"
+            );
+        }
+
+        for x in 32u8..=255 {
+            let bytes = [0xf8, x];
+            let mut decoder = Decoder::from(&bytes[..]);
+            assert_eq!(Header::Simple(x), decoder.pull().unwrap());
         }
     }
 

--- a/ciborium-ll/src/seg.rs
+++ b/ciborium-ll/src/seg.rs
@@ -130,6 +130,10 @@ impl<'r, R: Read, P: Parser> Segment<'r, R, P> {
     /// Gets the next parsed chunk within the segment
     ///
     /// Returns `Ok(None)` when all chunks have been read.
+    ///
+    /// Note that `buffer` must be able to hold the parser's saved bytes (see
+    /// `Parser::saved()`; at most 3 for text) plus at least one new byte.
+    /// A smaller buffer cannot make progress and results in an error.
     #[inline]
     pub fn pull<'a>(
         &mut self,
@@ -148,6 +152,12 @@ impl<'r, R: Read, P: Parser> Segment<'r, R, P> {
         let size = min(buffer.len(), prev + self.unread);
         let full = &mut buffer[..size];
         let next = &mut full[min(size, prev)..];
+
+        // A buffer that cannot hold the saved bytes plus at least one new
+        // byte cannot make progress; fail instead of looping forever.
+        if next.is_empty() {
+            return Err(Error::Syntax(self.offset));
+        }
 
         // Read additional bytes.
         self.reader.read_exact(next)?;

--- a/ciborium/src/de/mod.rs
+++ b/ciborium/src/de/mod.rs
@@ -184,20 +184,25 @@ where
                 match tag {
                     tag::BIGPOS | tag::BIGNEG => {
                         let mut bytes = Vec::new();
-                        let result =
-                            match self.integer(Some(Header::Tag(tag)), true, |b| bytes.push(b))? {
-                                (false, _) if !bytes.is_empty() => {
+                        match self.integer(Some(Header::Tag(tag)), true, |b| bytes.push(b))? {
+                            (false, _) if !bytes.is_empty() => {
+                                let access =
+                                    TagAccess::new(BytesDeserializer::new(&bytes), Some(tag));
+                                visitor.visit_enum(access)
+                            }
+                            (false, raw) => visitor.visit_u128(raw),
+                            (true, raw) => match i128::try_from(raw) {
+                                Ok(x) => visitor.visit_i128(x ^ !0),
+                                // The magnitude doesn't fit in i128; preserve
+                                // it as a tagged bignum, exactly like payloads
+                                // longer than 16 bytes.
+                                Err(..) => {
+                                    let buf = raw.to_be_bytes();
                                     let access =
-                                        TagAccess::new(BytesDeserializer::new(&bytes), Some(tag));
-                                    return visitor.visit_enum(access);
+                                        TagAccess::new(BytesDeserializer::new(&buf), Some(tag));
+                                    visitor.visit_enum(access)
                                 }
-                                (false, raw) => return visitor.visit_u128(raw),
-                                (true, raw) => i128::try_from(raw).map(|x| x ^ !0),
-                            };
-
-                        match result {
-                            Ok(x) => visitor.visit_i128(x),
-                            Err(..) => Err(de::Error::custom("integer too large")),
+                            },
                         }
                     }
 
@@ -607,15 +612,22 @@ where
         }
 
         loop {
-            match self.decoder.pull()? {
+            // An enum variant is either encoded as a map with a single entry
+            // (the variant name and its payload) or, for unit variants, as a
+            // bare text string. Remember which form we saw so that variant
+            // payload accesses cannot read past the enum item.
+            let map = match self.decoder.pull()? {
                 Header::Tag(..) => continue,
-                Header::Map(Some(1)) => (),
-                header @ Header::Text(..) => self.decoder.push(header),
+                Header::Map(Some(1)) => true,
+                header @ Header::Text(..) => {
+                    self.decoder.push(header);
+                    false
+                }
                 header => return Err(header.expected("enum")),
-            }
+            };
 
             return self.recurse(|me| {
-                let access = Access(me, Some(0));
+                let access = Enum(me, map);
                 visitor.visit_enum(access)
             });
         }
@@ -695,7 +707,15 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::EnumAccess<'de> for Access<'a, 'b, R>
+/// Variant access for an enum item
+///
+/// The boolean field indicates whether the variant was encoded as a
+/// single-entry map (`true`) or as a bare text string (`false`). A bare
+/// text string only encodes a unit variant; payload accesses in that form
+/// must not consume the following item from the stream.
+struct Enum<'a, 'b, R>(&'a mut Deserializer<'b, R>, bool);
+
+impl<'de, 'a, 'b, R: Read> de::EnumAccess<'de> for Enum<'a, 'b, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -712,7 +732,7 @@ where
     }
 }
 
-impl<'de, 'a, 'b, R: Read> de::VariantAccess<'de> for Access<'a, 'b, R>
+impl<'de, 'a, 'b, R: Read> de::VariantAccess<'de> for Enum<'a, 'b, R>
 where
     R::Error: core::fmt::Debug,
 {
@@ -720,6 +740,11 @@ where
 
     #[inline]
     fn unit_variant(self) -> Result<(), Self::Error> {
+        if self.1 {
+            // The map form carries a payload; require it to be a unit.
+            <() as de::Deserialize>::deserialize(&mut *self.0)?;
+        }
+
         Ok(())
     }
 
@@ -728,6 +753,13 @@ where
         self,
         seed: U,
     ) -> Result<U::Value, Self::Error> {
+        if !self.1 {
+            return Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"newtype variant",
+            ));
+        }
+
         seed.deserialize(&mut *self.0)
     }
 
@@ -737,6 +769,13 @@ where
         _len: usize,
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
+        if !self.1 {
+            return Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"tuple variant",
+            ));
+        }
+
         self.0.deserialize_any(visitor)
     }
 
@@ -746,6 +785,13 @@ where
         _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error> {
+        if !self.1 {
+            return Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"struct variant",
+            ));
+        }
+
         self.0.deserialize_any(visitor)
     }
 }
@@ -798,6 +844,10 @@ where
 /// Deserializes as CBOR from a type with [`impl
 /// ciborium_io::Read`](ciborium_io::Read), using a caller-specific buffer as a
 /// temporary scratch space.
+///
+/// The buffer must be at least 4 bytes for all inputs to be deserializable;
+/// smaller buffers may produce errors on inputs containing multi-byte UTF-8
+/// characters. Larger buffers improve performance.
 #[inline]
 pub fn from_reader_with_buffer<T: de::DeserializeOwned, R: Read>(
     reader: R,
@@ -856,7 +906,7 @@ where
 }
 
 /// Returns a deserializer with a specified scratch buffer
-/// amd maximum recursion limit. Inputs that are nested beyond the specified limit
+/// and maximum recursion limit. Inputs that are nested beyond the specified limit
 /// will result in [`Error::RecursionLimitExceeded`] .
 ///
 /// Set a high recursion limit at your own risk (of stack exhaustion)!

--- a/ciborium/src/value/canonical.rs
+++ b/ciborium/src/value/canonical.rs
@@ -50,13 +50,11 @@ pub fn cmp_value(v1: &Value, v2: &Value) -> Ordering {
         },
         (Bool(s), Bool(o)) => s.cmp(o),
         (Null, Null) => Ordering::Equal,
-        (Tag(t, v), Tag(ot, ov)) => match Value::from(*t).partial_cmp(&Value::from(*ot)) {
-            Some(Ordering::Equal) | None => match v.partial_cmp(ov) {
-                Some(x) => x,
-                None => serialized_canonical_cmp(v1, v2),
-            },
-            Some(x) => x,
-        },
+        // Tagged values (and everything else) are compared by their serialized
+        // bytes. Note that comparing the tag numbers first would be incorrect:
+        // canonical ordering is length-first over the whole encoded item, so a
+        // higher tag with a short payload can sort before a lower tag with a
+        // long payload.
         (_, _) => serialized_canonical_cmp(v1, v2),
     }
 }

--- a/ciborium/tests/error.rs
+++ b/ciborium/tests/error.rs
@@ -114,11 +114,14 @@ fn eof() -> Error<std::io::Error> {
     case("fd", Error::Syntax(0)),
     case("fe", Error::Syntax(0)),
 
-    // Reserved two-byte encodings of simple values:
-    case("f800", Error::Semantic(None, "invalid type: simple, expected known simple value".into())),
-    case("f801", Error::Semantic(None, "invalid type: simple, expected known simple value".into())),
-    case("f818", Error::Semantic(None, "invalid type: simple, expected known simple value".into())),
-    case("f81f", Error::Semantic(None, "invalid type: simple, expected known simple value".into())),
+    // Two-byte encodings of simple values below 32 are not well-formed
+    // (RFC 8949 section 3.3):
+    case("f800", Error::Syntax(0)),
+    case("f801", Error::Syntax(0)),
+    case("f814", Error::Syntax(0)),
+    case("f817", Error::Syntax(0)),
+    case("f818", Error::Syntax(0)),
+    case("f81f", Error::Syntax(0)),
 
     // Indefinite-length string chunks not of the correct type:
     case("5f00ff", Error::Syntax(1)),

--- a/ciborium/tests/regressions.rs
+++ b/ciborium/tests/regressions.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Regression tests for decoding correctness and robustness fixes.
+
+use ciborium::de::{from_reader, from_reader_with_buffer};
+use ciborium::value::{CanonicalValue, Value};
+use serde::Deserialize;
+
+/// A negative bignum whose magnitude fits in 16 bytes but exceeds `i128`
+/// must be preserved as `Value::Tag(3, bytes)`, exactly like longer payloads,
+/// and must round-trip.
+#[test]
+fn bigneg_16_byte_payload_is_preserved() {
+    // tag(3) + bytes(16 x 0xff) => -2^128
+    let bytes = hex::decode("c350ffffffffffffffffffffffffffffffff").unwrap();
+    let val: Value = from_reader(&bytes[..]).unwrap();
+    assert_eq!(val, Value::Tag(3, Box::new(Value::Bytes(vec![0xff; 16]))));
+
+    let mut out = Vec::new();
+    ciborium::ser::into_writer(&val, &mut out).unwrap();
+    assert_eq!(out, bytes);
+
+    // Typed deserialization must still reject it: it doesn't fit in i128.
+    let too_large: Result<i128, _> = from_reader(&bytes[..]);
+    assert!(too_large.is_err());
+}
+
+/// A scratch buffer too small to reassemble a multi-byte UTF-8 character
+/// must produce an error instead of looping forever.
+#[test]
+fn tiny_scratch_buffer_errors_instead_of_hanging() {
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&"héllo", &mut buf).unwrap();
+
+    let mut scratch = [0u8; 1];
+    let result: Result<String, _> = from_reader_with_buffer(&buf[..], &mut scratch);
+    assert!(result.is_err());
+
+    // A 4-byte scratch buffer is the documented minimum and must succeed.
+    let mut scratch = [0u8; 4];
+    let result: Result<String, _> = from_reader_with_buffer(&buf[..], &mut scratch);
+    assert_eq!(result.unwrap(), "héllo");
+}
+
+/// Two-byte encodings of simple values below 32 are not well-formed per
+/// RFC 8949 section 3.3. In particular, `f814` must not decode as `false`.
+#[test]
+fn two_byte_simple_values_are_rejected() {
+    for input in ["f814", "f815", "f816", "f817"] {
+        let bytes = hex::decode(input).unwrap();
+        let result: Result<Value, _> = from_reader(&bytes[..]);
+        assert!(result.is_err(), "{input} must be rejected");
+    }
+
+    // The one-byte encodings remain valid.
+    assert_eq!(
+        from_reader::<Value, _>(&hex::decode("f4").unwrap()[..]).unwrap(),
+        Value::Bool(false)
+    );
+    assert_eq!(
+        from_reader::<Value, _>(&hex::decode("f5").unwrap()[..]).unwrap(),
+        Value::Bool(true)
+    );
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+enum E {
+    Unit,
+    Newtype(u8),
+    Tuple(u8, u8),
+    Struct { a: u8 },
+}
+
+/// A map-form unit variant must consume its payload (and require it to be
+/// null) instead of leaving it dangling in the stream.
+#[test]
+fn enum_unit_variant_map_form() {
+    // [{"Unit": 5}, 7]: the dangling 5 used to be read as the next element.
+    let bytes = hex::decode("82a164556e69740507").unwrap();
+    let result: Result<(E, u8), _> = from_reader(&bytes[..]);
+    assert!(result.is_err(), "unit variant payload must be null");
+
+    // [{"Unit": null}, 7] is accepted and stays in sync.
+    let bytes = hex::decode("82a164556e6974f607").unwrap();
+    let result: (E, u8) = from_reader(&bytes[..]).unwrap();
+    assert_eq!(result, (E::Unit, 7));
+
+    // The canonical encoding (bare text) still works.
+    let bytes = hex::decode("8264556e697407").unwrap();
+    let result: (E, u8) = from_reader(&bytes[..]).unwrap();
+    assert_eq!(result, (E::Unit, 7));
+}
+
+/// A bare-text variant name must not satisfy a payload-carrying variant by
+/// consuming the following (sibling) item from the stream.
+#[test]
+fn enum_payload_variants_reject_bare_text_form() {
+    // ["Newtype", 7, 9]: "Newtype" used to consume the sibling 7 as payload.
+    let bytes = hex::decode("83674e6577747970650709").unwrap();
+    let result: Result<(E, u8, u8), _> = from_reader(&bytes[..]);
+    assert!(
+        result.is_err(),
+        "bare text must not satisfy a newtype variant"
+    );
+
+    // ["Tuple", 7, 9]
+    let bytes = hex::decode("83655475706c650709").unwrap();
+    let result: Result<(E, u8, u8), _> = from_reader(&bytes[..]);
+    assert!(
+        result.is_err(),
+        "bare text must not satisfy a tuple variant"
+    );
+
+    // ["Struct", 7, 9]
+    let bytes = hex::decode("8366537472756374 0709".replace(' ', "")).unwrap();
+    let result: Result<(E, u8, u8), _> = from_reader(&bytes[..]);
+    assert!(
+        result.is_err(),
+        "bare text must not satisfy a struct variant"
+    );
+
+    // The map forms still round-trip.
+    let bytes = hex::decode("82a1674e6577747970650507").unwrap();
+    let result: (E, u8) = from_reader(&bytes[..]).unwrap();
+    assert_eq!(result, (E::Newtype(5), 7));
+
+    let bytes = hex::decode("82a1655475706c65820509 07".replace(' ', "")).unwrap();
+    let result: (E, u8) = from_reader(&bytes[..]).unwrap();
+    assert_eq!(result, (E::Tuple(5, 9), 7));
+
+    let bytes = hex::decode("82a166537472756374a16161 05 07".replace(' ', "")).unwrap();
+    let result: (E, u8) = from_reader(&bytes[..]).unwrap();
+    assert_eq!(result, (E::Struct { a: 5 }, 7));
+}
+
+/// Canonical ordering of tagged values must follow the serialized bytes
+/// (length-first), not the derived `PartialOrd` of the inner values.
+#[test]
+fn canonical_tag_ordering_is_bytewise() {
+    // Tag(1, Bytes([])) -> c1 40 (2 bytes)
+    // Tag(1, Integer(1000)) -> c1 1903e8 (4 bytes)
+    let a = CanonicalValue::from(Value::Tag(1, Box::new(Value::Bytes(vec![]))));
+    let b = CanonicalValue::from(Value::Tag(1, Box::new(Value::Integer(1000.into()))));
+    assert!(a < b, "shorter serialization must sort first");
+
+    // Tag(1000, Integer(0)) -> d903e8 00 (4 bytes)
+    // Tag(23, Text("aaaaaaaaaa")) -> d7 6a 6161.. (12 bytes)
+    let c = CanonicalValue::from(Value::Tag(1000, Box::new(Value::Integer(0.into()))));
+    let d = CanonicalValue::from(Value::Tag(23, Box::new(Value::Text("aaaaaaaaaa".into()))));
+    assert!(c < d, "shorter serialization must sort first");
+
+    // Same tag, same length: lexical byte order. 0x0a (10) < 0x20 (-1).
+    let e = CanonicalValue::from(Value::Tag(1, Box::new(Value::Integer(10.into()))));
+    let f = CanonicalValue::from(Value::Tag(1, Box::new(Value::Integer((-1).into()))));
+    assert!(e < f, "equal length keys sort in lexical byte order");
+}


### PR DESCRIPTION
## Summary

A deep review of the codec against RFC 8949 found five real defects. Each was first confirmed with a failing reproduction test, then fixed; the reproductions are kept as regression tests in `ciborium/tests/regressions.rs`.

### 1. Infinite loop on undersized scratch buffers (DoS) — `ciborium-ll/src/seg.rs`

`Segment::pull()` looped forever returning empty chunks when the caller's buffer was smaller than the parser's saved bytes (or empty). Through `from_reader_with_buffer` with a scratch buffer under 4 bytes, this was an *input-dependent* hang on multi-byte UTF-8 text — attacker-controllable denial of service. It now returns `Error::Syntax` when no progress is possible, and the minimum buffer size is documented.

### 2. Enum variant stream desync (parse-state corruption) — `ciborium/src/de/mod.rs`

Two dual problems:

- A map-form unit variant (`{"Unit": v}`) returned without consuming `v`, leaving it dangling so subsequent fields parsed from the wrong stream position.
- A bare-text variant name satisfied newtype/tuple/struct variants by consuming the following **sibling** item as the payload.

The variant access now tracks whether the variant came from a single-entry map or a bare text string: the map form requires the unit payload to be null, and the text form only encodes unit variants. This matches the semantics the `Value`-based deserializer already enforced.

### 3. Accepting non-well-formed two-byte simple values — `ciborium-ll/src/hdr.rs`

`f814` (two-byte encoding of simple value 20) decoded as `false`. RFC 8949 §3.3 and the well-formedness check in Appendix C require rejecting `0xf8` followed by a byte below `0x20`. Accepting it gives the same value two encodings and creates parser differentials with strict implementations. Such inputs are now rejected as `Error::Syntax`.

### 4. 16-byte negative bignums failed to decode — `ciborium/src/de/mod.rs`

A `tag(3)` bignum whose magnitude fits in 16 bytes but exceeds `i128` (e.g. `-2^128`, `c350ffff…ff`) failed with `"integer too large"` when decoding into `Value`, while payloads of 17+ significant bytes were correctly preserved as `Value::Tag(3, bytes)`. The 16-byte case now falls back to the same tagged-bytes representation and round-trips losslessly. Typed deserialization (e.g. into `i128`) still rejects it as expected.

### 5. Canonical ordering of tagged values was wrong — `ciborium/src/value/canonical.rs`

`cmp_value` compared `(Tag, Tag)` inner values with the **derived** `PartialOrd`, which orders by enum variant declaration first (`Integer` always before `Bytes`, etc.) and violates RFC 8949 length-first ordering. Comparing tag numbers first is also incorrect: a higher tag with a short payload must sort before a lower tag with a long payload. Tagged values now delegate to the serialized-bytes comparison.

### Also included

- `Decoder::offset` now takes `&self` (non-breaking relaxation), plus stale-doc and typo fixes.
- `Header::Simple` documents that values 24–31 are reserved and have no valid encoding.
- New regression tests covering all of the above; `tests/error.rs` expectations updated for the reserved simple values (`Semantic` → `Syntax`, plus `f814`/`f817` cases).

## Behavior changes to note

Items 2 and 3 deliberately **tighten** decoding: malformed inputs that were previously accepted silently (with corrupted results) are now rejected. Well-formed data produced by ciborium or other conforming encoders is unaffected.

## Testing

- All 15 workspace test targets pass (including the 313-case codec matrix and fuzz test).
- `cargo clippy --workspace --all-targets`: clean. `cargo fmt --check`: clean.
- `cargo build -p ciborium --no-default-features`: builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)